### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,4 +1,6 @@
 name: Deploy Test Branch
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/toelpel/sc.urban-golf.ch/security/code-scanning/1](https://github.com/toelpel/sc.urban-golf.ch/security/code-scanning/1)

To fix this problem, add a `permissions:` block to either the workflow root (recommended, for simplicity) or directly under the `deploy` job. This block should assign only the least required privilege, typically `contents: read`, unless the workflow needs additional permissions. For this workflow, which checks out code and uploads via FTP, `contents: read` at the root level is sufficient. The fix involves inserting the following lines directly after the `name:` declaration at the top of `.github/workflows/deploy-test.yml`.

No additional methods or imports are required; this is a declarative configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
