### PR TITLE
Add compact ranking view and auto-compact mode for 5+ players

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "main": "app.js",
   "type": "module",
   "scripts": {
+    "build": "echo 'No build step required for backend'",
     "dev": "node app.js",
     "start": "node app.js",
     "test": "vitest run",

--- a/frontend/src/assets/global.css
+++ b/frontend/src/assets/global.css
@@ -252,6 +252,17 @@
   @apply bg-transparent;
 }
 
+/* Compact-Modus: kleinere Schrift & Padding bei vielen Spielern */
+.scorecard-compact .scorecard-header-cell {
+  @apply px-2 py-1 text-xs;
+}
+
+.scorecard-compact .scorecard-cell,
+.scorecard-compact .scorecard-player-cell,
+.scorecard-compact .scorecard-metric-cell {
+  @apply px-2 py-1 text-xs;
+}
+
 /* Animation für verschobene Listenelemente */
 .game-list-move {
   transition: transform 0.3s ease;

--- a/frontend/src/components/games/GamesDetailHorizontal.vue
+++ b/frontend/src/components/games/GamesDetailHorizontal.vue
@@ -1,7 +1,8 @@
 <template>
-    <div class="relative w-full overflow-x-auto">
+    <div class="relative w-full overflow-x-auto max-h-[calc(100dvh-11rem)] overflow-y-auto">
         <div class="glass-card p-0 inline-block min-w-full">
-            <table class="scorecard-table min-w-[42rem] w-full border-collapse">
+            <table class="scorecard-table min-w-[42rem] w-full border-collapse"
+                :class="{ 'scorecard-compact': players.length >= 5 }">
                 <thead class="backdrop-blur-md bg-white/40 dark:bg-gray-900/40">
                     <tr>
                         <th class="scorecard-header-cell cursor-pointer first:rounded-tl-2xl"

--- a/frontend/src/components/games/GamesDetailRanking.vue
+++ b/frontend/src/components/games/GamesDetailRanking.vue
@@ -1,0 +1,79 @@
+<template>
+    <div class="glass-card p-0 overflow-hidden">
+        <table class="scorecard-table w-full border-collapse">
+            <thead class="backdrop-blur-md bg-white/40 dark:bg-gray-900/40">
+                <tr>
+                    <th class="scorecard-header-cell text-center w-12 first:rounded-tl-2xl">
+                        #
+                    </th>
+                    <th class="scorecard-header-cell cursor-pointer border-l border-white/30 dark:border-white/10"
+                        @click="$emit('sort', 'name')">
+                        {{ $t('General.Player') }}
+                        <span v-if="sortColumn === 'name'">{{ sortDirectionSymbol }}</span>
+                    </th>
+                    <th class="scorecard-header-cell cursor-pointer w-16 text-center border-l border-white/30 dark:border-white/10"
+                        @click="$emit('sort', 'average')">
+                        Ø <span v-if="sortColumn === 'average'">{{ sortDirectionSymbol }}</span>
+                    </th>
+                    <th class="scorecard-header-cell cursor-pointer w-20 text-center border-l border-white/30 dark:border-white/10 last:rounded-tr-2xl"
+                        @click="$emit('sort', 'total')">
+                        {{ $t('General.Total') }}
+                        <span v-if="sortColumn === 'total'">{{ sortDirectionSymbol }}</span>
+                    </th>
+                </tr>
+            </thead>
+
+            <tbody>
+                <tr v-for="(player, index) in sortedPlayers" :key="player.id"
+                    class="hover:bg-white/30 dark:hover:bg-gray-800/30 transition"
+                    :class="{ 'ranking-podium': index < 3 }">
+                    <td class="scorecard-cell text-center font-bold" :class="rankClass(index)">
+                        {{ index + 1 }}
+                    </td>
+                    <td class="scorecard-player-cell" :class="rankTextClass(index)">
+                        {{ player.name }}
+                    </td>
+                    <td class="scorecard-metric-cell text-center">
+                        {{ averageScore(player.id) }}
+                    </td>
+                    <td class="scorecard-metric-cell text-center font-bold text-lg">
+                        {{ totalScore(player.id) }}
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Player } from '@/services/api'
+
+defineEmits<{
+  sort: [column: 'name' | 'total' | 'average']
+}>()
+
+const props = defineProps<{
+    sortColumn: string
+    sortDirection: string
+    sortedPlayers: Player[]
+    averageScore: (playerId: string) => string
+    totalScore: (playerId: string) => number
+}>()
+
+const sortDirectionSymbol = computed(() =>
+    props.sortDirection === 'asc' ? '↑' : '↓'
+)
+
+function rankClass(index: number): string {
+    if (index === 0) return 'text-yellow-500 dark:text-yellow-400'
+    if (index === 1) return 'text-gray-400 dark:text-gray-300'
+    if (index === 2) return 'text-amber-600 dark:text-amber-500'
+    return 'text-gray-500 dark:text-gray-400'
+}
+
+function rankTextClass(index: number): string {
+    if (index === 0) return 'font-bold'
+    return ''
+}
+</script>

--- a/frontend/src/components/games/GamesDetailVertical.vue
+++ b/frontend/src/components/games/GamesDetailVertical.vue
@@ -1,7 +1,8 @@
 <template>
     <div class="max-h-[calc(100dvh-11rem)] overflow-y-auto overflow-x-auto">
         <div class="glass-card p-0 overflow-hidden inline-block min-w-full">
-            <table class="scorecard-table w-full min-w-max border-collapse">
+            <table class="scorecard-table w-full min-w-max border-collapse"
+                :class="{ 'scorecard-compact': players.length >= 5 }">
                 <thead class="backdrop-blur-md bg-white/40 dark:bg-gray-900/40">
                     <tr>
                         <th class="scorecard-header-cell text-left first:rounded-tl-2xl">

--- a/frontend/src/composables/__tests__/useViewMode.test.ts
+++ b/frontend/src/composables/__tests__/useViewMode.test.ts
@@ -17,11 +17,20 @@ describe('useViewMode', () => {
       expect(viewMode.value).toBe('vertical')
     })
 
-    it('switches from vertical to horizontal', () => {
+    it('switches from vertical to ranking', () => {
       const players = ref([{ id: 'p1', name: 'Player 1' }])
       const holes = ref([1, 2, 3])
       const { viewMode, toggleView } = useViewMode(players, holes)
       viewMode.value = 'vertical'
+      toggleView()
+      expect(viewMode.value).toBe('ranking')
+    })
+
+    it('switches from ranking to horizontal', () => {
+      const players = ref([{ id: 'p1', name: 'Player 1' }])
+      const holes = ref([1, 2, 3])
+      const { viewMode, toggleView } = useViewMode(players, holes)
+      viewMode.value = 'ranking'
       toggleView()
       expect(viewMode.value).toBe('horizontal')
     })
@@ -44,6 +53,15 @@ describe('useViewMode', () => {
       const { viewMode, loadPreference } = useViewMode(players, holes)
       loadPreference()
       expect(viewMode.value).toBe('vertical')
+    })
+
+    it('loads saved ranking preference from localStorage', () => {
+      localStorage.setItem('GamesDetailView', 'ranking')
+      const players = ref([{ id: 'p1', name: 'Player 1' }])
+      const holes = ref([1, 2, 3])
+      const { viewMode, loadPreference } = useViewMode(players, holes)
+      loadPreference()
+      expect(viewMode.value).toBe('ranking')
     })
 
     it('defaults to horizontal when many players and few holes', () => {

--- a/frontend/src/composables/useViewMode.ts
+++ b/frontend/src/composables/useViewMode.ts
@@ -1,14 +1,14 @@
 import { ref, watch, type Ref } from 'vue'
 import type { Player } from '@/services/api'
 
-type ViewMode = 'horizontal' | 'vertical'
+type ViewMode = 'horizontal' | 'vertical' | 'ranking'
 
 export function useViewMode(players: Ref<Player[]>, holes: Ref<number[]>) {
   const viewMode = ref<ViewMode>('horizontal')
 
   function loadPreference() {
     const saved = localStorage.getItem('GamesDetailView')
-    if (saved === 'horizontal' || saved === 'vertical') {
+    if (saved === 'horizontal' || saved === 'vertical' || saved === 'ranking') {
       viewMode.value = saved
     } else {
       viewMode.value =
@@ -16,8 +16,11 @@ export function useViewMode(players: Ref<Player[]>, holes: Ref<number[]>) {
     }
   }
 
+  const viewModes: ViewMode[] = ['horizontal', 'vertical', 'ranking']
+
   function toggleView() {
-    viewMode.value = viewMode.value === 'horizontal' ? 'vertical' : 'horizontal'
+    const idx = viewModes.indexOf(viewMode.value)
+    viewMode.value = viewModes[(idx + 1) % viewModes.length]
   }
 
   watch(viewMode, (val) => {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -99,7 +99,10 @@
     "Email": "Email (optional)"
   },
   "Scorecard": {
-    "Loading": "Lade Spieler und Scores ..."
+    "Loading": "Lade Spieler und Scores ...",
+    "ViewHorizontal": "Horizontale Ansicht",
+    "ViewVertical": "Vertikale Ansicht",
+    "ViewRanking": "Rangliste"
   },
   "Games": {
     "ListGames": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -100,7 +100,10 @@
     "Email": "Email (optional)"
   },
   "Scorecard": {
-    "Loading": "Loading players and scores..."
+    "Loading": "Loading players and scores...",
+    "ViewHorizontal": "Horizontal view",
+    "ViewVertical": "Vertical view",
+    "ViewRanking": "Ranking"
   },
   "Games": {
     "ListGames": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -99,7 +99,10 @@
     "Email": "Email (optionnel)"
   },
   "Scorecard": {
-    "Loading": "Chargement des joueurs et des scores..."
+    "Loading": "Chargement des joueurs et des scores...",
+    "ViewHorizontal": "Vue horizontale",
+    "ViewVertical": "Vue verticale",
+    "ViewRanking": "Classement"
   },
   "Games": {
     "ListGames": {

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -99,7 +99,10 @@
     "Email": "E-mail (optioneel)"
   },
   "Scorecard": {
-    "Loading": "Spelers en scores laden..."
+    "Loading": "Spelers en scores laden...",
+    "ViewHorizontal": "Horizontale weergave",
+    "ViewVertical": "Verticale weergave",
+    "ViewRanking": "Ranglijst"
   },
   "Games": {
     "ListGames": {

--- a/frontend/src/pages/games/GamesPage.vue
+++ b/frontend/src/pages/games/GamesPage.vue
@@ -10,9 +10,11 @@
           <h1 class="maintitle mb-4 truncate max-w-[70vw]" :title="gameName">
             {{ displayName }}
           </h1>
-          <button @click="toggleView" class="flex items-center justify-center w-8 h-8 -mt-2 rounded-md bg-gray-200 text-sm text-gray-800 shadow hover:bg-gray-300
+          <button @click="toggleView" :title="viewModeLabel" class="flex items-center justify-center w-8 h-8 -mt-2 rounded-md bg-gray-200 text-sm text-gray-800 shadow hover:bg-gray-300
          dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 transition">
-            <ArrowPathIcon class="w-5 h-5" />
+            <TableCellsIcon v-if="viewMode === 'horizontal'" class="w-5 h-5" />
+            <ListBulletIcon v-else-if="viewMode === 'vertical'" class="w-5 h-5" />
+            <TrophyIcon v-else class="w-5 h-5" />
           </button>
         </div>
 
@@ -24,9 +26,11 @@
           <GamesDetailHorizontal v-if="viewMode === 'horizontal'" :players="sortedPlayers" :holes="holes"
             :scores="scores" :game-id="gameId" :sort-column="sortColumn" :sort-direction="sortDirection"
             :sorted-players="sortedPlayers" :average-score="averageScore" :total-score="totalScore" @sort="sortBy" />
-          <GamesDetailVertical v-else :players="sortedPlayers" :holes="holes" :scores="scores" :game-id="gameId"
-            :sort-column="sortColumn" :sort-direction="sortDirection" :sorted-players="sortedPlayers"
-            :average-score="averageScore" :total-score="totalScore" @sort="sortBy" />
+          <GamesDetailVertical v-else-if="viewMode === 'vertical'" :players="sortedPlayers" :holes="holes"
+            :scores="scores" :game-id="gameId" :sort-column="sortColumn" :sort-direction="sortDirection"
+            :sorted-players="sortedPlayers" :average-score="averageScore" :total-score="totalScore" @sort="sortBy" />
+          <GamesDetailRanking v-else :sort-column="sortColumn" :sort-direction="sortDirection"
+            :sorted-players="sortedPlayers" :average-score="averageScore" :total-score="totalScore" @sort="sortBy" />
         </div>
       </template>
     </template>
@@ -38,11 +42,13 @@ import DefaultLayout from '@/layouts/DefaultLayout.vue'
 import GamesListCompact from '@/components/games/GamesListCompact.vue'
 import GamesDetailHorizontal from '@/components/games/GamesDetailHorizontal.vue'
 import GamesDetailVertical from '@/components/games/GamesDetailVertical.vue'
+import GamesDetailRanking from '@/components/games/GamesDetailRanking.vue'
 import GamesHoleView from '@/components/games/GamesHoleView.vue'
 
-import { ArrowPathIcon } from '@heroicons/vue/24/solid'
+import { ArrowPathIcon, TrophyIcon, TableCellsIcon, ListBulletIcon } from '@heroicons/vue/24/solid'
 import { computed, provide, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 
 import { useGamesDetailData } from '@/composables/useGamesDetailData'
 import { useSortedPlayers } from '@/composables/useSortedPlayers'
@@ -51,6 +57,7 @@ import { gamesDetailKey } from '@/types'
 import { shortGameName } from '@/utils/format'
 
 const route = useRoute()
+const { t } = useI18n()
 const gameId = computed(() => route.params.gameId as string)
 const hasValidGameId = computed(() =>
   typeof gameId.value === 'string' && /^[a-zA-Z0-9_-]{10,30}$/.test(gameId.value)
@@ -82,6 +89,15 @@ const {
   toggleView,
   loadPreference: loadViewPreference
 } = useViewMode(players, holes)
+
+const viewModeLabel = computed(() => {
+  const labels: Record<string, string> = {
+    horizontal: t('Scorecard.ViewHorizontal'),
+    vertical: t('Scorecard.ViewVertical'),
+    ranking: t('Scorecard.ViewRanking')
+  }
+  return labels[viewMode.value] ?? ''
+})
 
 function sortBy(column: 'name' | 'total' | 'average') {
   if (sortColumn.value === column) {


### PR DESCRIPTION
Adds a new ranking view (trophy icon) showing only rank, name, average and total — ideal for score announcements with many players. Existing horizontal/vertical views auto-shrink font and padding when 5+ players are present. Also adds missing backend build script for workspace compat.