### PR TITLE
Fix player colors changing on sort and add root vitest project config

### DIFF
--- a/frontend/src/composables/usePlayerColors.ts
+++ b/frontend/src/composables/usePlayerColors.ts
@@ -17,7 +17,8 @@ const PLAYER_COLORS = [
 export function usePlayerColors(players: Ref<Player[]>) {
   const colorMap = computed(() => {
     const map: Record<string, typeof PLAYER_COLORS[0]> = {}
-    players.value.forEach((player, i) => {
+    const stable = [...players.value].sort((a, b) => a.id.localeCompare(b.id))
+    stable.forEach((player, i) => {
       map[player.id] = PLAYER_COLORS[i % PLAYER_COLORS.length]
     })
     return map

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  test: {
+    name: 'frontend',
+    globals: true,
+    environment: 'happy-dom',
+    include: ['src/**/*.{test,spec}.{js,ts}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      include: ['src/**/*.{ts,vue}'],
+      exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/main.ts', 'src/env.d.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    projects: [
+      'frontend/vitest.config.ts',
+      'backend/vitest.config.js',
+    ],
+  },
+})


### PR DESCRIPTION
Stabilize player color assignment by sorting players by ID before mapping colors, preventing colors from shifting when table columns are sorted. Add root vitest.config.ts with Vitest 4 projects setup and dedicated frontend vitest.config.ts to fix test failures when running from monorepo root (missing happy-dom, unresolved @ alias, Playwright e2e tests leaking into unit test runs).