### PR TITLE
Update GitHub owner from toelpel to st-albani

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Siehe [.github/workflows/ci.yml](.github/workflows/ci.yml).
 
 ### Issue tracker
 
-Issues live in `toelpel/sc.urban-golf.ch` on GitHub via the `gh` CLI. See [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md).
+Issues live in `st-albani/sc.urban-golf.ch` on GitHub via the `gh` CLI. See [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md).
 
 ### Triage labels
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Entwicklungs-Flow.
 ## Setup
 
 ```bash
-git clone https://github.com/toelpel/sc.urban-golf.ch.git
+git clone https://github.com/st-albani/sc.urban-golf.ch.git
 cd sc.urban-golf.ch
 npm install                                # installiert beide Workspaces
 docker compose -f docker-compose.dev.yml up -d postgres

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -106,8 +106,8 @@ building locally when possible.
 
 **Pull the latest tagged images:**
 ```bash
-docker pull ghcr.io/toelpel/urbangolf-backend:latest
-docker pull ghcr.io/toelpel/urbangolf-frontend:latest
+docker pull ghcr.io/st-albani/urbangolf-backend:latest
+docker pull ghcr.io/st-albani/urbangolf-frontend:latest
 ```
 
 **Or build locally:**

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sc.urban-golf.ch/
 ### Mit Docker (empfohlen, alles in einem)
 
 ```bash
-git clone https://github.com/toelpel/sc.urban-golf.ch.git
+git clone https://github.com/st-albani/sc.urban-golf.ch.git
 cd sc.urban-golf.ch
 docker compose -f docker-compose.dev.yml up -d
 ```
@@ -113,5 +113,5 @@ MIT — frei nutzen, modifizieren und teilen mit Urheberhinweis.
 
 ## 📬 Contact
 
-Open an issue on [GitHub](https://github.com/toelpel/sc.urban-golf.ch/issues) oder via
+Open an issue on [GitHub](https://github.com/st-albani/sc.urban-golf.ch/issues) oder via
 `/feedback` direkt aus der App.

--- a/frontend/public/CHANGELOG.md
+++ b/frontend/public/CHANGELOG.md
@@ -29,7 +29,7 @@
 ## [2.0.1] – 2025-08-15
 ### 🎉 Milestones
 - The project is now open source and we're happy for your contribution 🎉
--- https://github.com/toelpel/sc.urban-golf.ch
+-- https://github.com/st-albani/sc.urban-golf.ch
 
 ### ✨ New features
 - Infinite scolling in Games-List

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -74,7 +74,7 @@
         },
         "OpenSource": {
           "Label": "Open Source",
-          "Desc": "Code will be publicly available on GitHub.\nCollaboration highly welcome 🤩\n → https://github.com/toelpel/sc.urban-golf.ch"
+          "Desc": "Code will be publicly available on GitHub.\nCollaboration highly welcome 🤩\n → https://github.com/st-albani/sc.urban-golf.ch"
         },
         "UserManagement": {
           "Label": "User Management",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -73,7 +73,7 @@
         },
         "OpenSource": {
           "Label": "Open Source",
-          "Desc": "Le code sera disponible publiquement sur GitHub.\nCollaboration vivement souhaitée 🤩\n → https://github.com/toelpel/sc.urban-golf.ch"
+          "Desc": "Le code sera disponible publiquement sur GitHub.\nCollaboration vivement souhaitée 🤩\n → https://github.com/st-albani/sc.urban-golf.ch"
         },
         "UserManagement": {
           "Label": "Gestion des utilisateurs",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -73,7 +73,7 @@
         },
         "OpenSource": {
           "Label": "Open Source",
-          "Desc": "Code wordt openbaar beschikbaar op GitHub.\nSamenwerking zeer gewenst 🤩\n → https://github.com/toelpel/sc.urban-golf.ch"
+          "Desc": "Code wordt openbaar beschikbaar op GitHub.\nSamenwerking zeer gewenst 🤩\n → https://github.com/st-albani/sc.urban-golf.ch"
         },
         "UserManagement": {
           "Label": "Gebruikersbeheer",


### PR DESCRIPTION
## Summary
- Repo wurde in die `st-albani`-Organisation transferiert
- Ersetzt alle Hard-codierten `toelpel`-Referenzen in Docs, i18n-Locales und Changelog
- CI/CD-Workflows nutzen bereits `${{ github.repository_owner }}` → keine Anpassung nötig
- Dockerfiles enthalten keine Owner-Referenzen → keine Anpassung nötig

## Betroffene Dateien
- `README.md` (Clone-URL, Issues-Link)
- `CONTRIBUTING.md` (Clone-URL)
- `CLAUDE.md` (Agent Issue-Tracker Referenz)
- `DEPLOYMENT.md` (docker pull Beispiel)
- `frontend/src/locales/{en,fr,nl}.json` (User-facing Roadmap-Link)
- `frontend/public/CHANGELOG.md` (Footer-Link)

## Test plan
- [ ] CI grün (static-checks, unit-frontend, unit-backend, e2e-smoke)
- [ ] Nach Merge: prüfen dass `ghcr.io/st-albani/urbangolf-{backend,frontend}` Images erstellt werden
- [ ] Nach Merge: GHCR-Packages ggf. auf `public` setzen falls Prod-Pull ohne Auth erfolgt

🤖 Generated with [Claude Code](https://claude.com/claude-code)