### PR TITLE
Fix stale URLs in sitemap.xml

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -4,7 +4,7 @@
     <loc>https://sc.urban-golf.ch/games</loc>
   </url>
   <url>
-    <loc>https://sct.urban-golf.ch/games/new</loc>
+    <loc>https://sc.urban-golf.ch/games/new</loc>
   </url>
   <url>
     <loc>https://sc.urban-golf.ch/feedback</loc>
@@ -13,6 +13,6 @@
     <loc>https://sc.urban-golf.ch/about</loc>
   </url>
   <url>
-    <loc>https://sc.urban-golf.ch//about/roadmap</loc>
+    <loc>https://sc.urban-golf.ch/about/roadmap</loc>
   </url>
 </urlset>


### PR DESCRIPTION
Korrigiert zwei fehlerhafte URLs in `frontend/public/sitemap.xml`:
- `https://sct.urban-golf.ch/games/new` → `https://sc.urban-golf.ch/games/new` (Tippfehler im Host)
- `https://sc.urban-golf.ch//about/roadmap` → `https://sc.urban-golf.ch/about/roadmap` (doppelter Slash)

Die GitHub-Org-Umbenennung (`toelpel` → `st-albani`) wird separat in #74 behandelt — dieser PR enthält nur noch die Sitemap-Korrekturen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)