### PR TITLE
Loch-Vollständigkeit & Sync-Status-Indikator (PRD #81)

### DIFF
--- a/frontend/e2e/smoke/hole-completion.spec.ts
+++ b/frontend/e2e/smoke/hole-completion.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from './fixtures'
+
+test.describe('Loch-Vollständigkeit (Smoke)', () => {
+  const gameId = 'mock-game-alpha-2026' // 4 Spieler, Löcher 1–3 vollständig erfasst
+
+  test('zeigt "4/4 erfasst" wenn alle Spieler einen Score haben', async ({ page, mockApi }) => {
+    void mockApi
+    await page.goto(`/games/${gameId}/1`)
+    const completion = page.locator('.hole-completion')
+    await expect(completion).toContainText('4/4')
+    await expect(completion).toHaveClass(/is-complete/)
+    // Keine Spieler-Kachel ist als fehlend markiert
+    await expect(page.locator('.player-tile--missing')).toHaveCount(0)
+  })
+
+  test('markiert fehlende Spieler auf einem leeren Loch und zählt beim Eintragen hoch', async ({ page, mockApi }) => {
+    void mockApi
+    // Loch 4 wurde noch nie erfasst → alle 4 Spieler fehlen
+    await page.goto(`/games/${gameId}/4`)
+    const completion = page.locator('.hole-completion')
+    await expect(completion).toContainText('0/4')
+    await expect(completion).not.toHaveClass(/is-complete/)
+    await expect(page.locator('.player-tile--missing')).toHaveCount(4)
+
+    // Score für Anna eintragen → Zähler 1/4, Annas Kachel nicht mehr fehlend
+    const annaTile = page.locator('.player-tile', { hasText: 'Anna Meier' })
+    await annaTile.getByRole('button', { name: 'Mehr Schläge' }).click()
+    await expect(completion).toContainText('1/4')
+    await expect(annaTile).not.toHaveClass(/player-tile--missing/)
+    await expect(page.locator('.player-tile--missing')).toHaveCount(3)
+  })
+})

--- a/frontend/e2e/smoke/hole-completion.spec.ts
+++ b/frontend/e2e/smoke/hole-completion.spec.ts
@@ -1,31 +1,24 @@
 import { test, expect } from './fixtures'
 
-test.describe('Loch-Vollständigkeit (Smoke)', () => {
+test.describe('Fehlende-Spieler-Markierung (Smoke)', () => {
   const gameId = 'mock-game-alpha-2026' // 4 Spieler, Löcher 1–3 vollständig erfasst
 
-  test('zeigt "4/4 erfasst" wenn alle Spieler einen Score haben', async ({ page, mockApi }) => {
+  test('keine Kachel ist als fehlend markiert, wenn alle einen Score haben', async ({ page, mockApi }) => {
     void mockApi
     await page.goto(`/games/${gameId}/1`)
-    const completion = page.locator('.hole-completion')
-    await expect(completion).toContainText('4/4')
-    await expect(completion).toHaveClass(/is-complete/)
-    // Keine Spieler-Kachel ist als fehlend markiert
+    await expect(page.locator('.player-tile').first()).toBeVisible()
     await expect(page.locator('.player-tile--missing')).toHaveCount(0)
   })
 
-  test('markiert fehlende Spieler auf einem leeren Loch und zählt beim Eintragen hoch', async ({ page, mockApi }) => {
+  test('markiert fehlende Spieler auf einem leeren Loch und hebt die Markierung beim Eintragen auf', async ({ page, mockApi }) => {
     void mockApi
     // Loch 4 wurde noch nie erfasst → alle 4 Spieler fehlen
     await page.goto(`/games/${gameId}/4`)
-    const completion = page.locator('.hole-completion')
-    await expect(completion).toContainText('0/4')
-    await expect(completion).not.toHaveClass(/is-complete/)
     await expect(page.locator('.player-tile--missing')).toHaveCount(4)
 
-    // Score für Anna eintragen → Zähler 1/4, Annas Kachel nicht mehr fehlend
+    // Score für Anna eintragen → ihre Kachel ist nicht mehr fehlend
     const annaTile = page.locator('.player-tile', { hasText: 'Anna Meier' })
     await annaTile.getByRole('button', { name: 'Mehr Schläge' }).click()
-    await expect(completion).toContainText('1/4')
     await expect(annaTile).not.toHaveClass(/player-tile--missing/)
     await expect(page.locator('.player-tile--missing')).toHaveCount(3)
   })

--- a/frontend/e2e/smoke/hole-pills.spec.ts
+++ b/frontend/e2e/smoke/hole-pills.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from './fixtures'
+
+test.describe('Loch-Pill-Vollständigkeit (Smoke)', () => {
+  const gameId = 'mock-game-alpha-2026' // 4 Spieler, Löcher 1–3 vollständig erfasst
+
+  test('Loch-Chips der Detailansicht markieren vollständige Löcher', async ({ page, mockApi }) => {
+    void mockApi
+    await page.goto(`/games/${gameId}`)
+    // Löcher 1–3 sind für alle 4 Spieler erfasst → drei vollständige Chips mit Häkchen
+    const complete = page.locator('.games-detail__hole-chip.is-complete')
+    await expect(complete).toHaveCount(3)
+    await expect(page.locator('.games-detail__hole-chip.is-complete .games-detail__hole-check').first()).toBeVisible()
+  })
+
+  test('Pill wechselt von teilweise auf vollständig, sobald alle Spieler erfasst sind', async ({ page, mockApi }) => {
+    void mockApi
+    // Loch 4 ist noch nie erfasst worden
+    await page.goto(`/games/${gameId}/4`)
+
+    // Erster Score → Loch-Pill 4 erscheint und ist "teilweise"
+    const players = ['Anna Meier', 'Boris Wild', 'Christian Schmid', 'David Huber']
+    await page.locator('.player-tile', { hasText: players[0] })
+      .getByRole('button', { name: 'Mehr Schläge' }).click()
+
+    // Pill per href ansteuern und die Add-Pill ausschließen — robust gegenüber
+    // Icon/Textinhalt und dem "+1"-Chip.
+    const pill4 = page.locator(
+      `a.hole-progress__chip:not(.hole-progress__chip--add)[href$="/${gameId}/4"]`
+    )
+    await expect(pill4).toHaveClass(/is-partial/)
+    await expect(pill4).not.toHaveClass(/is-complete/)
+
+    // Restliche Spieler ausfüllen → Pill wird vollständig
+    for (const name of players.slice(1)) {
+      await page.locator('.player-tile', { hasText: name })
+        .getByRole('button', { name: 'Mehr Schläge' }).click()
+    }
+
+    await expect(pill4).toHaveClass(/is-complete/)
+    await expect(pill4.locator('.hole-progress__check')).toBeVisible()
+  })
+})

--- a/frontend/e2e/smoke/score-entry.spec.ts
+++ b/frontend/e2e/smoke/score-entry.spec.ts
@@ -53,7 +53,8 @@ test.describe('Score-Entry Hole-View (Smoke)', () => {
   test('Hole-Pill Navigation wechselt das Loch', async ({ page, mockApi }) => {
     void mockApi
     await page.goto(`/games/${gameId}/1`)
-    await page.locator('.hole-progress__chip', { hasText: /^2$/ }).click()
+    // Pill per href ansteuern — robust gegenüber Icon/Textinhalt der Pill.
+    await page.locator(`a.hole-progress__chip[href$="/${gameId}/2"]`).click()
     await expect(page).toHaveURL(new RegExp(`/games/${gameId}/2$`))
     await expect(page.locator('.hole-header__number')).toHaveText('2')
   })

--- a/frontend/e2e/smoke/sync-status.spec.ts
+++ b/frontend/e2e/smoke/sync-status.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from './fixtures'
+
+test.describe('Sync-Status-Indikator (Smoke)', () => {
+  const gameId = 'mock-game-alpha-2026'
+
+  test('bleibt versteckt solange online und nichts ausstehend ist', async ({ page, mockApi }) => {
+    void mockApi
+    await page.goto(`/games/${gameId}/1`)
+    await expect(page.locator('.player-tile').first()).toBeVisible()
+    await expect(page.locator('.sync-status')).toBeHidden()
+  })
+
+  test('zeigt Offline-Status, zählt ausstehende Änderungen und verschwindet nach Reconnect', async ({ page, context, mockApi }) => {
+    void mockApi
+    await page.goto(`/games/${gameId}/1`)
+    await expect(page.locator('.player-tile').first()).toBeVisible()
+
+    const indicator = page.locator('.sync-status')
+
+    // Offline gehen → Indikator erscheint
+    await context.setOffline(true)
+    await expect(indicator).toBeVisible()
+    await expect(indicator).toContainText('Offline')
+
+    // Score offline eintragen → wandert in die Queue → Zähler steigt
+    const anna = page.locator('.player-tile', { hasText: 'Anna Meier' })
+    await anna.getByRole('button', { name: 'Mehr Schläge' }).click()
+    await expect(indicator).toContainText('1')
+
+    // Wieder online → Queue wird geflusht → Indikator verschwindet
+    await context.setOffline(false)
+    await expect(indicator).toBeHidden()
+  })
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
-    "@playwright/test": "^1.49.0",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^6.0.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,6 +2,7 @@
   <BackgroundImage />
   <router-view />
   <ToastContainer />
+  <SyncStatusIndicator />
   <PWAUpdateDialog />
   <PWAInstallBanner />
 </template>
@@ -9,6 +10,7 @@
 <script setup lang="ts">
 import BackgroundImage from '@/components/ui/BackgroundImage.vue'
 import ToastContainer from '@/components/ui/ToastContainer.vue'
+import SyncStatusIndicator from '@/components/layout/SyncStatusIndicator.vue'
 import PWAUpdateDialog from '@/components/pwa/PWAUpdateDialog.vue'
 import PWAInstallBanner from '@/components/pwa/PWAInstallBanner.vue'
 import { useScoreSyncStore } from '@/stores/scoreSync'

--- a/frontend/src/components/games/GamesHoleView.vue
+++ b/frontend/src/components/games/GamesHoleView.vue
@@ -53,9 +53,9 @@
       </div>
     </header>
 
-    <!-- Fortschritt: Loch-Pills + kompakter Vollständigkeits-Zähler in einer
-         Reihe. Der Zähler ersetzt die frühere eigene Zeile und spart Höhe;
-         der volle Text bleibt als aria-label für Screenreader erhalten. -->
+    <!-- Fortschritt: Loch-Pills. Der Add-Button liegt bewusst ausserhalb des
+         scrollenden Containers, damit er bei vielen Löchern nicht am rechten
+         Rand abgeschnitten wird. -->
     <div class="hole-progress-row">
       <div ref="pillsRef" class="hole-progress scroll-hide" role="list">
         <router-link
@@ -74,26 +74,15 @@
           {{ n }}
           <CheckIcon v-if="holeStateFor(n) === 'complete'" class="hole-progress__check" aria-hidden="true" />
         </router-link>
-        <router-link
-          :to="`/games/${gameId}/${nextNewHole}`"
-          class="hole-progress__chip hole-progress__chip--add"
-          :aria-label="$t('General.Hole') + ' +1'"
-        >
-          <PlusIcon class="w-3.5 h-3.5" />
-        </router-link>
       </div>
 
-      <span
-        v-if="players.length"
-        class="hole-completion"
-        :class="{ 'is-complete': currentComplete }"
-        role="status"
-        aria-live="polite"
-        :aria-label="$t('Games.HoleView.Completion', { done: currentCompletion.done, total: currentCompletion.total })"
+      <router-link
+        :to="`/games/${gameId}/${nextNewHole}`"
+        class="hole-progress__chip hole-progress__chip--add"
+        :aria-label="$t('General.Hole') + ' +1'"
       >
-        <CheckIcon v-if="currentComplete" class="hole-completion__icon" aria-hidden="true" />
-        {{ currentCompletion.done }}/{{ currentCompletion.total }}
-      </span>
+        <PlusIcon class="w-3.5 h-3.5" />
+      </router-link>
     </div>
 
     <!-- Spieler-Karten -->
@@ -229,13 +218,10 @@ const context = inject(gamesDetailKey)!
 const { players, scores, holes, gameName } = context
 const { saveScore: saveScoreOffline } = useScoreSyncStore()
 const { colorMap } = usePlayerColors(players)
-const { hasScore, completion, isComplete, holeState } = useHoleCompletion(players, scores)
+const { hasScore, holeState } = useHoleCompletion(players, scores)
 
 const displayName = computed(() => shortGameName(gameName.value))
 
-// Vollständigkeit des aktuell geöffneten Lochs
-const currentCompletion = computed(() => completion(hole.value))
-const currentComplete = computed(() => isComplete(hole.value))
 function hasCurrentScore(playerId: string) {
   return hasScore(playerId, hole.value)
 }
@@ -543,48 +529,17 @@ function ensureScoreFieldsExist() {
   font-variant-numeric: tabular-nums;
 }
 
-/* Loch-Pills + Vollständigkeits-Zähler teilen sich eine Reihe */
+/* Loch-Pills + Add-Button teilen sich eine Reihe */
 .hole-progress-row {
   display: flex;
   align-items: center;
   gap: 0.6rem;
 }
 
-/* Kompakter Vollständigkeits-Zähler rechts neben den Pills */
-.hole-completion {
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.3rem 0.6rem;
-  border-radius: var(--radius-pill);
-  background: color-mix(in oklab, var(--text-default) 6%, transparent);
-  color: var(--text-muted);
-  font-size: var(--text-sm);
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  line-height: 1;
-}
-
-.hole-completion.is-complete {
-  background: color-mix(in oklab, var(--color-success-500) 16%, transparent);
-  color: color-mix(in oklab, var(--color-success-600) 80%, var(--text-strong));
-}
-
-:root.dark .hole-completion.is-complete {
-  color: var(--color-success-400);
-}
-
-.hole-completion__icon {
-  width: 0.9rem;
-  height: 0.9rem;
-  flex-shrink: 0;
-  stroke-width: 2.5;
-}
-
-/* Progress pills */
+/* Progress pills — wachsen nicht (bleiben links, "+1" direkt daneben),
+   schrumpfen aber und scrollen, wenn viele Löcher nicht mehr passen. */
 .hole-progress {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-width: 0;
   display: flex;
   gap: 0.4rem;

--- a/frontend/src/components/games/GamesHoleView.vue
+++ b/frontend/src/components/games/GamesHoleView.vue
@@ -53,6 +53,19 @@
       </div>
     </header>
 
+    <!-- Vollständigkeit des aktuellen Lochs: "X/Y erfasst". aria-live kündigt
+         Änderungen für Screenreader an, ohne den Fokus zu verschieben. -->
+    <p
+      v-if="players.length"
+      class="hole-completion"
+      :class="{ 'is-complete': currentComplete }"
+      role="status"
+      aria-live="polite"
+    >
+      <CheckCircleIcon v-if="currentComplete" class="hole-completion__icon" aria-hidden="true" />
+      <span>{{ $t('Games.HoleView.Completion', { done: currentCompletion.done, total: currentCompletion.total }) }}</span>
+    </p>
+
     <!-- Fortschritt: Loch-Pills — aktives Loch wird automatisch zentriert -->
     <div ref="pillsRef" class="hole-progress scroll-hide" role="list">
       <router-link
@@ -62,11 +75,14 @@
         :to="`/games/${gameId}/${n}`"
         :class="['hole-progress__chip', {
           'is-current': n === hole,
-          'is-filled': isFilled(n),
+          'is-partial': holeStateFor(n) === 'partial',
+          'is-complete': holeStateFor(n) === 'complete',
         }]"
+        :aria-label="pillAriaLabel(n)"
         role="listitem"
       >
         {{ n }}
+        <CheckIcon v-if="holeStateFor(n) === 'complete'" class="hole-progress__check" aria-hidden="true" />
       </router-link>
       <router-link
         :to="`/games/${gameId}/${nextNewHole}`"
@@ -87,6 +103,7 @@
         v-for="player in players"
         :key="player.id"
         class="player-tile"
+        :class="{ 'player-tile--missing': !hasCurrentScore(player.id) }"
         :style="{ '--player-accent': colorMap[player.id]?.color }"
       >
         <div class="player-tile__identity">
@@ -96,6 +113,9 @@
             size="md"
           />
           <h2 class="player-tile__name" :title="player.name">{{ player.name }}</h2>
+          <span v-if="!hasCurrentScore(player.id)" class="player-tile__missing-badge">
+            {{ $t('Games.HoleView.MissingScore') }}
+          </span>
         </div>
 
         <div class="player-tile__controls">
@@ -115,7 +135,7 @@
             class="stroke-value"
             :class="{ 'is-saving': savingMap[player.id] }"
             @click="openKeypad(player.id)"
-            :aria-label="$t('Games.HoleView.ScoreFor', { player: player.name }) + ': ' + (scores[player.id]?.[hole] ?? '–')"
+            :aria-label="$t('Games.HoleView.ScoreFor', { player: player.name }) + ': ' + (hasCurrentScore(player.id) ? scores[player.id]?.[hole] : $t('Games.HoleView.MissingScore'))"
             :aria-busy="savingMap[player.id] || undefined"
           >
             {{ scores[player.id]?.[hole] ?? '–' }}
@@ -182,9 +202,11 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount, watch, inject } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { useScoreSyncStore } from '@/stores/scoreSync'
 import { usePlayerColors } from '@/composables/usePlayerColors'
+import { useHoleCompletion } from '@/composables/useHoleCompletion'
 import { gamesDetailKey } from '@/types'
 import { shortGameName } from '@/utils/format'
 import { VALIDATION } from '@/constants'
@@ -194,11 +216,12 @@ import PlayerAvatar from '@/components/ui/PlayerAvatar.vue'
 import {
   MinusIcon, PlusIcon,
   ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon,
-  PencilSquareIcon,
+  PencilSquareIcon, CheckCircleIcon, CheckIcon,
 } from '@heroicons/vue/24/outline'
 
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 const gameId = computed(() => route.params.gameId as string)
 const hole = computed(() => parseInt(route.params.holeId as string))
 
@@ -206,8 +229,29 @@ const context = inject(gamesDetailKey)!
 const { players, scores, holes, gameName } = context
 const { saveScore: saveScoreOffline } = useScoreSyncStore()
 const { colorMap } = usePlayerColors(players)
+const { hasScore, completion, isComplete, holeState } = useHoleCompletion(players, scores)
 
 const displayName = computed(() => shortGameName(gameName.value))
+
+// Vollständigkeit des aktuell geöffneten Lochs
+const currentCompletion = computed(() => completion(hole.value))
+const currentComplete = computed(() => isComplete(hole.value))
+function hasCurrentScore(playerId: string) {
+  return hasScore(playerId, hole.value)
+}
+
+/** Pill-Zustand eines Lochs für die Fortschrittsleiste. */
+function holeStateFor(holeNum: number) {
+  return holeState(holeNum)
+}
+
+/** Beschreibt den Pill-Zustand für Screenreader (nicht nur farblich). */
+function pillAriaLabel(holeNum: number) {
+  const state = holeState(holeNum)
+  if (state === 'complete') return t('Games.HoleView.PillComplete', { n: holeNum })
+  if (state === 'partial') return t('Games.HoleView.PillPartial', { n: holeNum })
+  return `${t('General.Hole')} ${holeNum}`
+}
 
 const strokeRange = computed(() => {
   const { STROKES_MIN: min, STROKES_MAX: max } = VALIDATION
@@ -223,13 +267,6 @@ const nextNewHole = computed(() => {
   const max = holes.value.length ? Math.max(...holes.value) : 0
   return Math.min(VALIDATION.HOLE_MAX, max + 1)
 })
-
-function isFilled(holeNum: number) {
-  return players.value.some(p => {
-    const v = scores.value[p.id]?.[holeNum]
-    return v !== undefined && v !== '' && v !== null
-  })
-}
 
 // Score element refs for pulse animation
 const scoreRefs: Record<string, HTMLElement | null> = {}
@@ -506,6 +543,37 @@ function ensureScoreFieldsExist() {
   font-variant-numeric: tabular-nums;
 }
 
+/* Vollständigkeits-Zähler des aktuellen Lochs */
+.hole-completion {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  align-self: flex-start;
+  padding: 0.25rem 0.7rem;
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklab, var(--text-default) 7%, transparent);
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  margin-top: -0.15rem;
+}
+
+.hole-completion.is-complete {
+  background: color-mix(in oklab, var(--color-success-500) 16%, transparent);
+  color: color-mix(in oklab, var(--color-success-600) 80%, var(--text-strong));
+}
+
+:root.dark .hole-completion.is-complete {
+  color: var(--color-success-400);
+}
+
+.hole-completion__icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
 /* Progress pills */
 .hole-progress {
   display: flex;
@@ -536,10 +604,31 @@ function ensureScoreFieldsExist() {
 
 .hole-progress__chip:active { transform: scale(0.94); }
 
-.hole-progress__chip.is-filled {
+/* Teilweise erfasst: mindestens ein, aber nicht alle Spieler. */
+.hole-progress__chip.is-partial {
   color: var(--primary);
-  background: color-mix(in oklab, var(--primary) 14%, var(--card-bg));
-  border-color: color-mix(in oklab, var(--primary) 25%, var(--card-border));
+  background: color-mix(in oklab, var(--primary) 12%, var(--card-bg));
+  border-color: color-mix(in oklab, var(--primary) 22%, var(--card-border));
+}
+
+/* Vollständig für alle Spieler: Success-Tint + Häkchen (nicht nur farblich). */
+.hole-progress__chip.is-complete {
+  color: color-mix(in oklab, var(--color-success-600) 85%, var(--text-strong));
+  background: color-mix(in oklab, var(--color-success-500) 16%, var(--card-bg));
+  border-color: color-mix(in oklab, var(--color-success-500) 32%, var(--card-border));
+  padding-inline: 0.55rem 0.5rem;
+}
+
+:root.dark .hole-progress__chip.is-complete {
+  color: var(--color-success-400);
+}
+
+.hole-progress__check {
+  width: 0.9rem;
+  height: 0.9rem;
+  margin-left: 0.15rem;
+  flex-shrink: 0;
+  stroke-width: 2.5;
 }
 
 .hole-progress__chip.is-current {
@@ -597,6 +686,13 @@ function ensureScoreFieldsExist() {
   box-shadow: 3px 0 8px -5px color-mix(in oklab, var(--player-accent) 20%, transparent);
 }
 
+/* Loch noch nicht für diesen Spieler erfasst: dezente Hervorhebung, damit
+   die Lücke ins Auge springt, ohne die Farbakzente zu dominieren. */
+.player-tile--missing {
+  border-color: color-mix(in oklab, var(--color-warning-500) 45%, var(--card-border));
+  background: color-mix(in oklab, var(--color-warning-500) 6%, var(--card-bg));
+}
+
 .player-tile__identity {
   grid-area: identity;
   display: flex;
@@ -604,6 +700,22 @@ function ensureScoreFieldsExist() {
   gap: 0.6rem;
   min-width: 0;
   padding-left: 0.3rem;
+}
+
+.player-tile__missing-badge {
+  flex-shrink: 0;
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklab, var(--color-warning-500) 20%, transparent);
+  color: color-mix(in oklab, var(--color-warning-600) 85%, var(--text-strong));
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+:root.dark .player-tile__missing-badge {
+  color: var(--color-warning-400);
 }
 
 .player-tile__name {

--- a/frontend/src/components/games/GamesHoleView.vue
+++ b/frontend/src/components/games/GamesHoleView.vue
@@ -53,44 +53,47 @@
       </div>
     </header>
 
-    <!-- Vollständigkeit des aktuellen Lochs: "X/Y erfasst". aria-live kündigt
-         Änderungen für Screenreader an, ohne den Fokus zu verschieben. -->
-    <p
-      v-if="players.length"
-      class="hole-completion"
-      :class="{ 'is-complete': currentComplete }"
-      role="status"
-      aria-live="polite"
-    >
-      <CheckCircleIcon v-if="currentComplete" class="hole-completion__icon" aria-hidden="true" />
-      <span>{{ $t('Games.HoleView.Completion', { done: currentCompletion.done, total: currentCompletion.total }) }}</span>
-    </p>
+    <!-- Fortschritt: Loch-Pills + kompakter Vollständigkeits-Zähler in einer
+         Reihe. Der Zähler ersetzt die frühere eigene Zeile und spart Höhe;
+         der volle Text bleibt als aria-label für Screenreader erhalten. -->
+    <div class="hole-progress-row">
+      <div ref="pillsRef" class="hole-progress scroll-hide" role="list">
+        <router-link
+          v-for="n in holes"
+          :key="n"
+          :ref="el => setPillRef(n, el as unknown as { $el?: HTMLElement } | HTMLElement | null)"
+          :to="`/games/${gameId}/${n}`"
+          :class="['hole-progress__chip', {
+            'is-current': n === hole,
+            'is-partial': holeStateFor(n) === 'partial',
+            'is-complete': holeStateFor(n) === 'complete',
+          }]"
+          :aria-label="pillAriaLabel(n)"
+          role="listitem"
+        >
+          {{ n }}
+          <CheckIcon v-if="holeStateFor(n) === 'complete'" class="hole-progress__check" aria-hidden="true" />
+        </router-link>
+        <router-link
+          :to="`/games/${gameId}/${nextNewHole}`"
+          class="hole-progress__chip hole-progress__chip--add"
+          :aria-label="$t('General.Hole') + ' +1'"
+        >
+          <PlusIcon class="w-3.5 h-3.5" />
+        </router-link>
+      </div>
 
-    <!-- Fortschritt: Loch-Pills — aktives Loch wird automatisch zentriert -->
-    <div ref="pillsRef" class="hole-progress scroll-hide" role="list">
-      <router-link
-        v-for="n in holes"
-        :key="n"
-        :ref="el => setPillRef(n, el as unknown as { $el?: HTMLElement } | HTMLElement | null)"
-        :to="`/games/${gameId}/${n}`"
-        :class="['hole-progress__chip', {
-          'is-current': n === hole,
-          'is-partial': holeStateFor(n) === 'partial',
-          'is-complete': holeStateFor(n) === 'complete',
-        }]"
-        :aria-label="pillAriaLabel(n)"
-        role="listitem"
+      <span
+        v-if="players.length"
+        class="hole-completion"
+        :class="{ 'is-complete': currentComplete }"
+        role="status"
+        aria-live="polite"
+        :aria-label="$t('Games.HoleView.Completion', { done: currentCompletion.done, total: currentCompletion.total })"
       >
-        {{ n }}
-        <CheckIcon v-if="holeStateFor(n) === 'complete'" class="hole-progress__check" aria-hidden="true" />
-      </router-link>
-      <router-link
-        :to="`/games/${gameId}/${nextNewHole}`"
-        class="hole-progress__chip hole-progress__chip--add"
-        :aria-label="$t('General.Hole') + ' +1'"
-      >
-        <PlusIcon class="w-3.5 h-3.5" />
-      </router-link>
+        <CheckIcon v-if="currentComplete" class="hole-completion__icon" aria-hidden="true" />
+        {{ currentCompletion.done }}/{{ currentCompletion.total }}
+      </span>
     </div>
 
     <!-- Spieler-Karten -->
@@ -113,9 +116,6 @@
             size="md"
           />
           <h2 class="player-tile__name" :title="player.name">{{ player.name }}</h2>
-          <span v-if="!hasCurrentScore(player.id)" class="player-tile__missing-badge">
-            {{ $t('Games.HoleView.MissingScore') }}
-          </span>
         </div>
 
         <div class="player-tile__controls">
@@ -138,7 +138,7 @@
             :aria-label="$t('Games.HoleView.ScoreFor', { player: player.name }) + ': ' + (hasCurrentScore(player.id) ? scores[player.id]?.[hole] : $t('Games.HoleView.MissingScore'))"
             :aria-busy="savingMap[player.id] || undefined"
           >
-            {{ scores[player.id]?.[hole] ?? '–' }}
+            {{ hasCurrentScore(player.id) ? scores[player.id]?.[hole] : '–' }}
           </button>
 
           <button
@@ -216,7 +216,7 @@ import PlayerAvatar from '@/components/ui/PlayerAvatar.vue'
 import {
   MinusIcon, PlusIcon,
   ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon,
-  PencilSquareIcon, CheckCircleIcon, CheckIcon,
+  PencilSquareIcon, CheckIcon,
 } from '@heroicons/vue/24/outline'
 
 const route = useRoute()
@@ -543,20 +543,27 @@ function ensureScoreFieldsExist() {
   font-variant-numeric: tabular-nums;
 }
 
-/* Vollständigkeits-Zähler des aktuellen Lochs */
+/* Loch-Pills + Vollständigkeits-Zähler teilen sich eine Reihe */
+.hole-progress-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* Kompakter Vollständigkeits-Zähler rechts neben den Pills */
 .hole-completion {
+  flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  align-self: flex-start;
-  padding: 0.25rem 0.7rem;
+  gap: 0.25rem;
+  padding: 0.3rem 0.6rem;
   border-radius: var(--radius-pill);
-  background: color-mix(in oklab, var(--text-default) 7%, transparent);
+  background: color-mix(in oklab, var(--text-default) 6%, transparent);
   color: var(--text-muted);
   font-size: var(--text-sm);
-  font-weight: 600;
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
-  margin-top: -0.15rem;
+  line-height: 1;
 }
 
 .hole-completion.is-complete {
@@ -569,13 +576,16 @@ function ensureScoreFieldsExist() {
 }
 
 .hole-completion__icon {
-  width: 1rem;
-  height: 1rem;
+  width: 0.9rem;
+  height: 0.9rem;
   flex-shrink: 0;
+  stroke-width: 2.5;
 }
 
 /* Progress pills */
 .hole-progress {
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   gap: 0.4rem;
   overflow-x: auto;
@@ -666,6 +676,7 @@ function ensureScoreFieldsExist() {
   box-shadow: var(--shadow-elev-1);
   position: relative;
   overflow: hidden;
+  transition: background 240ms var(--ease-standard);
 }
 
 .player-tile::before {
@@ -678,6 +689,7 @@ function ensureScoreFieldsExist() {
   background: var(--player-accent);
   border-radius: 0 3px 3px 0;
   box-shadow: 3px 0 10px -4px color-mix(in oklab, var(--player-accent) 25%, transparent);
+  transition: opacity 240ms var(--ease-standard);
 }
 
 :root.dark .player-tile::before {
@@ -686,11 +698,19 @@ function ensureScoreFieldsExist() {
   box-shadow: 3px 0 8px -5px color-mix(in oklab, var(--player-accent) 20%, transparent);
 }
 
-/* Loch noch nicht für diesen Spieler erfasst: dezente Hervorhebung, damit
-   die Lücke ins Auge springt, ohne die Farbakzente zu dominieren. */
+/* Loch noch nicht für diesen Spieler erfasst: ruhige, "wartende" Kachel.
+   Der farbige Akzentbalken leuchtet erst beim Erfassen voll auf und der
+   "–"-Wert ist gedämpft — kein Badge, damit der Name nie verdeckt wird. */
 .player-tile--missing {
-  border-color: color-mix(in oklab, var(--color-warning-500) 45%, var(--card-border));
-  background: color-mix(in oklab, var(--color-warning-500) 6%, var(--card-bg));
+  background: color-mix(in oklab, var(--text-default) 4%, var(--card-bg));
+}
+
+.player-tile--missing::before {
+  opacity: 0.4;
+}
+
+.player-tile--missing .stroke-value {
+  color: var(--text-muted);
 }
 
 .player-tile__identity {
@@ -700,22 +720,6 @@ function ensureScoreFieldsExist() {
   gap: 0.6rem;
   min-width: 0;
   padding-left: 0.3rem;
-}
-
-.player-tile__missing-badge {
-  flex-shrink: 0;
-  padding: 0.1rem 0.5rem;
-  border-radius: var(--radius-pill);
-  background: color-mix(in oklab, var(--color-warning-500) 20%, transparent);
-  color: color-mix(in oklab, var(--color-warning-600) 85%, var(--text-strong));
-  font-size: var(--text-xs);
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  white-space: nowrap;
-}
-
-:root.dark .player-tile__missing-badge {
-  color: var(--color-warning-400);
 }
 
 .player-tile__name {

--- a/frontend/src/components/layout/SyncStatusIndicator.vue
+++ b/frontend/src/components/layout/SyncStatusIndicator.vue
@@ -1,0 +1,133 @@
+<template>
+  <Transition name="sync-status">
+    <div
+      v-if="visible"
+      class="sync-status"
+      :class="`sync-status--${tone}`"
+      role="status"
+      aria-live="polite"
+    >
+      <component
+        :is="icon"
+        class="sync-status__icon"
+        :class="{ 'sync-status__icon--spin': tone === 'syncing' }"
+        aria-hidden="true"
+      />
+      <span class="sync-status__text">{{ label }}</span>
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useOnline } from '@vueuse/core'
+import { ArrowPathIcon, SignalSlashIcon } from '@heroicons/vue/24/outline'
+import { useSyncQueueStore } from '@/stores/syncQueue'
+import { useSyncStatus } from '@/composables/useSyncStatus'
+
+const { t } = useI18n()
+const isOnline = useOnline()
+const queueStore = useSyncQueueStore()
+
+const pending = computed(() => queueStore.queue.length)
+const { tone, visible } = useSyncStatus(isOnline, pending)
+
+const icon = computed(() => (tone.value === 'syncing' ? ArrowPathIcon : SignalSlashIcon))
+
+const label = computed(() => {
+  switch (tone.value) {
+    case 'syncing':
+      return t('Sync.Syncing', { n: pending.value })
+    case 'offline-pending':
+      return t('Sync.OfflinePending', { n: pending.value })
+    case 'offline':
+      return t('Sync.Offline')
+    default:
+      return ''
+  }
+})
+</script>
+
+<style scoped>
+/* Dezenter, nicht-blockierender Status-Pill oberhalb der Bottom-Nav. */
+.sync-status {
+  position: fixed;
+  left: 50%;
+  bottom: calc(var(--spacing-nav-height, 4rem) + var(--spacing-safe-bottom) + 0.6rem);
+  transform: translateX(-50%);
+  z-index: 45;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  max-width: calc(100vw - 2rem);
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius-pill);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--shadow-elev-2);
+  color: var(--text-default);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  pointer-events: none;
+}
+
+/* Auf Desktop ist die Bottom-Nav ausgeblendet — Pill rückt näher an den Rand. */
+@media (min-width: 768px) {
+  .sync-status {
+    bottom: calc(var(--spacing-safe-bottom) + 1rem);
+  }
+}
+
+.sync-status--offline,
+.sync-status--offline-pending {
+  color: color-mix(in oklab, var(--color-warning-600) 85%, var(--text-strong));
+  border-color: color-mix(in oklab, var(--color-warning-500) 40%, var(--card-border));
+  background: color-mix(in oklab, var(--color-warning-500) 8%, var(--card-bg));
+}
+
+:root.dark .sync-status--offline,
+:root.dark .sync-status--offline-pending {
+  color: var(--color-warning-400);
+}
+
+.sync-status__icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex-shrink: 0;
+}
+
+.sync-status__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.sync-status__icon--spin {
+  animation: sync-spin 1s linear infinite;
+}
+
+@keyframes sync-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Ein-/Ausblenden */
+.sync-status-enter-active,
+.sync-status-leave-active {
+  transition: opacity 220ms var(--ease-standard), transform 220ms var(--ease-standard);
+}
+.sync-status-enter-from,
+.sync-status-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(0.5rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sync-status__icon--spin { animation: none; }
+  .sync-status-enter-active,
+  .sync-status-leave-active { transition: opacity 220ms var(--ease-standard); }
+  .sync-status-enter-from,
+  .sync-status-leave-to { transform: translateX(-50%); }
+}
+</style>

--- a/frontend/src/composables/__tests__/useHoleCompletion.test.ts
+++ b/frontend/src/composables/__tests__/useHoleCompletion.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useHoleCompletion } from '../useHoleCompletion'
+import type { Player } from '@/services/api'
+import type { ScoreMap } from '@/types'
+
+function setup() {
+  const players = ref<Player[]>([
+    { id: 'p1', name: 'Anna' },
+    { id: 'p2', name: 'Boris' },
+    { id: 'p3', name: 'Chris' },
+  ])
+  const scores = ref<ScoreMap>({
+    // Loch 1: alle drei erfasst
+    p1: { 1: 3, 2: 4 },
+    p2: { 1: 4, 2: '' }, // Loch 2 nur Platzhalter → nicht erfasst
+    p3: { 1: 0 },        // 0 Schläge ist ein gültiger Score → erfasst
+  })
+  return { players, scores }
+}
+
+describe('useHoleCompletion', () => {
+  it('treats 0 as a valid score but empty string / missing as not entered', () => {
+    const { players, scores } = setup()
+    const { hasScore } = useHoleCompletion(players, scores)
+    expect(hasScore('p3', 1)).toBe(true)  // strokes 0
+    expect(hasScore('p2', 2)).toBe(false) // empty string placeholder
+    expect(hasScore('p3', 2)).toBe(false) // undefined
+  })
+
+  it('reports every player as missing when no scores exist for a hole', () => {
+    const { players, scores } = setup()
+    const { missingPlayers, completion, holeState } = useHoleCompletion(players, scores)
+    expect(missingPlayers(9).map((p) => p.id)).toEqual(['p1', 'p2', 'p3'])
+    expect(completion(9)).toEqual({ done: 0, total: 3 })
+    expect(holeState(9)).toBe('empty')
+  })
+
+  it('reports no missing players and complete state when every player has a score', () => {
+    const { players, scores } = setup()
+    const { missingPlayers, completion, holeState, isComplete } = useHoleCompletion(players, scores)
+    expect(missingPlayers(1)).toEqual([])
+    expect(completion(1)).toEqual({ done: 3, total: 3 })
+    expect(holeState(1)).toBe('complete')
+    expect(isComplete(1)).toBe(true)
+  })
+
+  it('reports partial state and the exact missing players', () => {
+    const { players, scores } = setup()
+    const { missingPlayers, completion, holeState, isComplete } = useHoleCompletion(players, scores)
+    // Loch 2: nur p1 hat einen echten Score, p2='' und p3=undefined fehlen
+    expect(missingPlayers(2).map((p) => p.id)).toEqual(['p2', 'p3'])
+    expect(completion(2)).toEqual({ done: 1, total: 3 })
+    expect(holeState(2)).toBe('partial')
+    expect(isComplete(2)).toBe(false)
+  })
+
+  it('is reactive to score changes', () => {
+    const { players, scores } = setup()
+    const { completion, holeState } = useHoleCompletion(players, scores)
+    expect(holeState(2)).toBe('partial')
+    scores.value.p2[2] = 5
+    scores.value.p3[2] = 6
+    expect(completion(2)).toEqual({ done: 3, total: 3 })
+    expect(holeState(2)).toBe('complete')
+  })
+
+  it('treats an empty player list as empty, never complete', () => {
+    const players = ref<Player[]>([])
+    const scores = ref<ScoreMap>({})
+    const { holeState, isComplete, completion } = useHoleCompletion(players, scores)
+    expect(completion(1)).toEqual({ done: 0, total: 0 })
+    expect(holeState(1)).toBe('empty')
+    expect(isComplete(1)).toBe(false)
+  })
+})

--- a/frontend/src/composables/__tests__/useSyncStatus.test.ts
+++ b/frontend/src/composables/__tests__/useSyncStatus.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useSyncStatus } from '../useSyncStatus'
+
+describe('useSyncStatus', () => {
+  it('is idle and hidden when online with an empty queue', () => {
+    const { tone, visible } = useSyncStatus(ref(true), ref(0))
+    expect(tone.value).toBe('idle')
+    expect(visible.value).toBe(false)
+  })
+
+  it('shows syncing when online with pending items', () => {
+    const { tone, visible } = useSyncStatus(ref(true), ref(3))
+    expect(tone.value).toBe('syncing')
+    expect(visible.value).toBe(true)
+  })
+
+  it('shows offline (no count) when offline with an empty queue', () => {
+    const { tone, visible } = useSyncStatus(ref(false), ref(0))
+    expect(tone.value).toBe('offline')
+    expect(visible.value).toBe(true)
+  })
+
+  it('shows offline-pending when offline with queued items', () => {
+    const { tone, visible } = useSyncStatus(ref(false), ref(2))
+    expect(tone.value).toBe('offline-pending')
+    expect(visible.value).toBe(true)
+  })
+
+  it('reacts to network and queue changes', () => {
+    const online = ref(false)
+    const pending = ref(2)
+    const { tone, visible } = useSyncStatus(online, pending)
+    expect(tone.value).toBe('offline-pending')
+
+    // Reconnect → items flush in the background
+    online.value = true
+    expect(tone.value).toBe('syncing')
+    expect(visible.value).toBe(true)
+
+    // Flush completes
+    pending.value = 0
+    expect(tone.value).toBe('idle')
+    expect(visible.value).toBe(false)
+  })
+})

--- a/frontend/src/composables/useHoleCompletion.ts
+++ b/frontend/src/composables/useHoleCompletion.ts
@@ -1,0 +1,43 @@
+import { type Ref } from 'vue'
+import type { Player } from '@/services/api'
+import type { ScoreMap } from '@/types'
+
+export type HoleState = 'empty' | 'partial' | 'complete'
+
+/**
+ * Leitet pro Loch ab, für welche Spieler noch kein Score erfasst ist.
+ * Referenz für "vollständig" ist die aktive Spielerliste des Spiels.
+ *
+ * Ein leerer String ('') ist der Platzhalter für ein noch nicht eingegebenes
+ * Feld (siehe ensureScoreFieldsExist in der Hole-View) und zählt daher NICHT
+ * als erfasst — Number('') wäre sonst irreführend 0.
+ */
+export function useHoleCompletion(players: Ref<Player[]>, scores: Ref<ScoreMap>) {
+  function hasScore(playerId: string, hole: number): boolean {
+    const v = scores.value[playerId]?.[hole]
+    return v !== undefined && v !== null && v !== ''
+  }
+
+  function missingPlayers(hole: number): Player[] {
+    return players.value.filter((p) => !hasScore(p.id, hole))
+  }
+
+  function completion(hole: number): { done: number; total: number } {
+    const total = players.value.length
+    const done = players.value.reduce((acc, p) => acc + (hasScore(p.id, hole) ? 1 : 0), 0)
+    return { done, total }
+  }
+
+  function holeState(hole: number): HoleState {
+    const { done, total } = completion(hole)
+    if (total === 0 || done === 0) return 'empty'
+    return done === total ? 'complete' : 'partial'
+  }
+
+  function isComplete(hole: number): boolean {
+    const { done, total } = completion(hole)
+    return total > 0 && done === total
+  }
+
+  return { hasScore, missingPlayers, completion, holeState, isComplete }
+}

--- a/frontend/src/composables/useSyncStatus.ts
+++ b/frontend/src/composables/useSyncStatus.ts
@@ -1,0 +1,20 @@
+import { computed, type Ref } from 'vue'
+
+export type SyncTone = 'idle' | 'offline' | 'offline-pending' | 'syncing'
+
+/**
+ * Leitet aus Netzwerkstatus und Länge der Offline-Sync-Queue den anzuzeigenden
+ * Zustand des globalen Sync-Indikators ab. Reine Logik — die Zuordnung zu Text
+ * und Icon (inkl. i18n) passiert in der Komponente.
+ */
+export function useSyncStatus(isOnline: Ref<boolean>, pendingCount: Ref<number>) {
+  const tone = computed<SyncTone>(() => {
+    if (!isOnline.value) return pendingCount.value > 0 ? 'offline-pending' : 'offline'
+    return pendingCount.value > 0 ? 'syncing' : 'idle'
+  })
+
+  // Im Ruhezustand (online, nichts ausstehend) bleibt der Indikator verborgen.
+  const visible = computed(() => tone.value !== 'idle')
+
+  return { tone, visible }
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -184,7 +184,6 @@
       "KeypadShortcutHint": "Tipp: 1–7 auf der Tastatur",
       "StepperBack": "Zum vorherigen Loch ({n})",
       "StepperForward": "Zum nächsten Loch ({n})",
-      "Completion": "{done}/{total} erfasst",
       "MissingScore": "fehlt",
       "PillComplete": "Loch {n}, für alle erfasst",
       "PillPartial": "Loch {n}, teilweise erfasst"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -183,12 +183,21 @@
       "KeypadShowAll": "Alle anzeigen",
       "KeypadShortcutHint": "Tipp: 1–7 auf der Tastatur",
       "StepperBack": "Zum vorherigen Loch ({n})",
-      "StepperForward": "Zum nächsten Loch ({n})"
+      "StepperForward": "Zum nächsten Loch ({n})",
+      "Completion": "{done}/{total} erfasst",
+      "MissingScore": "fehlt",
+      "PillComplete": "Loch {n}, für alle erfasst",
+      "PillPartial": "Loch {n}, teilweise erfasst"
     }
   },
   "Network": {
     "Offline": "Du bist offline. Scores werden lokal gespeichert.",
     "BackOnline": "Wieder online. Scores werden synchronisiert."
+  },
+  "Sync": {
+    "Offline": "Offline",
+    "OfflinePending": "Offline · {n} ausstehend",
+    "Syncing": "Synchronisiere {n} …"
   },
   "Errors": {
     "RequestFailed": "Anfrage fehlgeschlagen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -184,12 +184,21 @@
       "KeypadShowAll": "Show all",
       "KeypadShortcutHint": "Tip: press 1–7 on your keyboard",
       "StepperBack": "Previous hole ({n})",
-      "StepperForward": "Next hole ({n})"
+      "StepperForward": "Next hole ({n})",
+      "Completion": "{done}/{total} recorded",
+      "MissingScore": "missing",
+      "PillComplete": "Hole {n}, recorded for everyone",
+      "PillPartial": "Hole {n}, partially recorded"
     }
   },
   "Network": {
     "Offline": "You're offline. Scores will be saved locally.",
     "BackOnline": "Back online. Syncing scores..."
+  },
+  "Sync": {
+    "Offline": "Offline",
+    "OfflinePending": "Offline · {n} pending",
+    "Syncing": "Syncing {n} …"
   },
   "Errors": {
     "RequestFailed": "Request failed",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -185,7 +185,6 @@
       "KeypadShortcutHint": "Tip: press 1–7 on your keyboard",
       "StepperBack": "Previous hole ({n})",
       "StepperForward": "Next hole ({n})",
-      "Completion": "{done}/{total} recorded",
       "MissingScore": "missing",
       "PillComplete": "Hole {n}, recorded for everyone",
       "PillPartial": "Hole {n}, partially recorded"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -183,12 +183,21 @@
       "KeypadShowAll": "Tout afficher",
       "KeypadShortcutHint": "Astuce : 1–7 au clavier",
       "StepperBack": "Trou précédent ({n})",
-      "StepperForward": "Trou suivant ({n})"
+      "StepperForward": "Trou suivant ({n})",
+      "Completion": "{done}/{total} saisis",
+      "MissingScore": "manquant",
+      "PillComplete": "Trou {n}, saisi pour tous",
+      "PillPartial": "Trou {n}, partiellement saisi"
     }
   },
   "Network": {
     "Offline": "Tu es hors ligne. Les scores seront sauvegardés localement.",
     "BackOnline": "De retour en ligne. Synchronisation des scores..."
+  },
+  "Sync": {
+    "Offline": "Hors ligne",
+    "OfflinePending": "Hors ligne · {n} en attente",
+    "Syncing": "Synchronisation de {n} …"
   },
   "Errors": {
     "RequestFailed": "Requête échouée",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -184,7 +184,6 @@
       "KeypadShortcutHint": "Astuce : 1–7 au clavier",
       "StepperBack": "Trou précédent ({n})",
       "StepperForward": "Trou suivant ({n})",
-      "Completion": "{done}/{total} saisis",
       "MissingScore": "manquant",
       "PillComplete": "Trou {n}, saisi pour tous",
       "PillPartial": "Trou {n}, partiellement saisi"

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -184,7 +184,6 @@
       "KeypadShortcutHint": "Tip: 1–7 op het toetsenbord",
       "StepperBack": "Vorige hole ({n})",
       "StepperForward": "Volgende hole ({n})",
-      "Completion": "{done}/{total} ingevoerd",
       "MissingScore": "ontbreekt",
       "PillComplete": "Hole {n}, voor iedereen ingevoerd",
       "PillPartial": "Hole {n}, gedeeltelijk ingevoerd"

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -183,12 +183,21 @@
       "KeypadShowAll": "Alles tonen",
       "KeypadShortcutHint": "Tip: 1–7 op het toetsenbord",
       "StepperBack": "Vorige hole ({n})",
-      "StepperForward": "Volgende hole ({n})"
+      "StepperForward": "Volgende hole ({n})",
+      "Completion": "{done}/{total} ingevoerd",
+      "MissingScore": "ontbreekt",
+      "PillComplete": "Hole {n}, voor iedereen ingevoerd",
+      "PillPartial": "Hole {n}, gedeeltelijk ingevoerd"
     }
   },
   "Network": {
     "Offline": "Je bent offline. Scores worden lokaal opgeslagen.",
     "BackOnline": "Weer online. Scores worden gesynchroniseerd..."
+  },
+  "Sync": {
+    "Offline": "Offline",
+    "OfflinePending": "Offline · {n} in wachtrij",
+    "Syncing": "{n} synchroniseren …"
   },
   "Errors": {
     "RequestFailed": "Verzoek mislukt",

--- a/frontend/src/pages/games/GamesPage.vue
+++ b/frontend/src/pages/games/GamesPage.vue
@@ -31,10 +31,15 @@
                 v-for="n in holes"
                 :key="n"
                 :to="`/games/${gameId}/${n}`"
-                class="games-detail__hole-chip"
+                :class="['games-detail__hole-chip', {
+                  'is-partial': holeState(n) === 'partial',
+                  'is-complete': holeState(n) === 'complete',
+                }]"
+                :aria-label="pillAriaLabel(n)"
                 role="listitem"
               >
                 {{ n }}
+                <CheckIcon v-if="holeState(n) === 'complete'" class="games-detail__hole-check" aria-hidden="true" />
               </router-link>
               <router-link
                 :to="`/games/${gameId}/${nextNewHole}`"
@@ -61,16 +66,19 @@ import GamesHoleView from '@/components/games/GamesHoleView.vue'
 import ErrorState from '@/components/ui/ErrorState.vue'
 import AppIconButton from '@/components/ui/AppIconButton.vue'
 
-import { PencilSquareIcon, PlusIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, PlusIcon, CheckIcon } from '@heroicons/vue/24/outline'
 import { computed, provide, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 
 import { useGamesDetailData } from '@/composables/useGamesDetailData'
+import { useHoleCompletion } from '@/composables/useHoleCompletion'
 import { gamesDetailKey } from '@/types'
 import { shortGameName } from '@/utils/format'
 import { VALIDATION } from '@/constants'
 
 const route = useRoute()
+const { t } = useI18n()
 const gameId = computed(() => route.params.gameId as string)
 const hasValidGameId = computed(() =>
   typeof gameId.value === 'string' && /^[a-zA-Z0-9_-]{10,30}$/.test(gameId.value)
@@ -80,6 +88,16 @@ const isHoleView = computed(() => 'holeId' in route.params)
 const { players, scores, holes, gameName, error, load: loadGamesDetailData } = useGamesDetailData(gameId)
 
 provide(gamesDetailKey, { players, scores, holes, gameName, error, load: loadGamesDetailData })
+
+const { holeState } = useHoleCompletion(players, scores)
+
+/** Beschreibt den Chip-Zustand für Screenreader (nicht nur farblich). */
+function pillAriaLabel(holeNum: number) {
+  const state = holeState(holeNum)
+  if (state === 'complete') return t('Games.HoleView.PillComplete', { n: holeNum })
+  if (state === 'partial') return t('Games.HoleView.PillPartial', { n: holeNum })
+  return `${t('General.Hole')} ${holeNum}`
+}
 
 async function reload() { await loadGamesDetailData() }
 
@@ -158,6 +176,33 @@ watchEffect(async () => {
 }
 
 .games-detail__hole-chip:active { transform: scale(0.94); }
+
+/* Teilweise erfasst: mindestens ein, aber nicht alle Spieler. */
+.games-detail__hole-chip.is-partial {
+  color: var(--primary);
+  background: color-mix(in oklab, var(--primary) 12%, var(--card-bg));
+  border-color: color-mix(in oklab, var(--primary) 22%, var(--card-border));
+}
+
+/* Vollständig für alle Spieler: Success-Tint + Häkchen (nicht nur farblich). */
+.games-detail__hole-chip.is-complete {
+  color: color-mix(in oklab, var(--color-success-600) 85%, var(--text-strong));
+  background: color-mix(in oklab, var(--color-success-500) 16%, var(--card-bg));
+  border-color: color-mix(in oklab, var(--color-success-500) 32%, var(--card-border));
+  padding-inline: 0.55rem 0.5rem;
+}
+
+:root.dark .games-detail__hole-chip.is-complete {
+  color: var(--color-success-400);
+}
+
+.games-detail__hole-check {
+  width: 0.95rem;
+  height: 0.95rem;
+  margin-left: 0.15rem;
+  flex-shrink: 0;
+  stroke-width: 2.5;
+}
 
 .games-detail__hole-chip--add {
   color: var(--text-muted);

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.0",
-        "@playwright/test": "^1.49.0",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.0.0",
         "@vitejs/plugin-vue": "^6.0.0",
@@ -2340,13 +2340,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8459,13 +8459,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8478,9 +8478,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
Setzt **PRD #81** um — Loch-Vollständigkeit („Wer fehlt noch?") und ein sichtbarer Offline-/Sync-Status — in drei vertikalen Slices.

## Was drin ist

- **#85 — Fehlende Spieler pro Loch:** ein `useHoleCompletion`-Composable leitet aus der vorhandenen ScoreMap ab, für welche Spieler ein Loch noch keinen Score hat. In der Hole-View erscheinen fehlende Spieler ruhig gedämpft (gedämpfter „–"-Wert, abgeblendeter Farbakzent); erfasste Kacheln „leuchten auf" (voller Akzentbalken + fette Zahl). Screenreader-Ansage „fehlt" pro Spieler.
- **#86 — Loch-Pill-Zustände:** Pills in der Hole-View und der Detail-Chip-Leiste unterscheiden leer / teilweise / vollständig-für-alle — mit ✓-Glyph (nicht nur farblich) und aria-labels. Der „+1"-Add-Button liegt jetzt ausserhalb des scrollenden Containers und bleibt bei jeder Loch-Anzahl sichtbar/klickbar.
- **#87 — Sync-Status-Indikator:** ein globaler, nicht-blockierender Indikator zeigt Offline-Zustand und die Anzahl ausstehender Änderungen, getrieben von einem reinen `useSyncStatus`-Composable über der bestehenden Sync-Queue.

Alle neuen Strings in **de/en/fr/nl**.

## Design-Iteration (nach visuellem Review)

- „X/Y erfasst"-Zähler wieder entfernt (wirkte kontextlos) — das Aufleuchten der Kacheln ist Signal genug.
- „missing"-Text-Badge entfernt (verdeckte den Spielernamen).
- „+1"-Add-Button aus dem Scroll-Container gelöst (war ab ~4–5 Löchern abgeschnitten).

## Tests

- Unit-Tests (Vitest) für `useHoleCompletion` und `useSyncStatus`
- Smoke-Tests (Playwright + Mock-API) für Fehlend-Markierung, Pill-Zustände und Sync-Status
- `npm run test:all` grün: Lint · Type-Check · Unit · 40 Smoke-Tests (Mobile + Desktop)

## Hinweise für den Review

- Enthält einen kleinen Chore-Commit: `@playwright/test` 1.59 → 1.61 (richtet den Browser-Build auf die lokal vorhandene Chromium-Revision aus).
- Nicht enthalten: einige bereits vor dieser Arbeit im Working-Tree liegende, unzusammenhängende Änderungen (`docker-compose*`, `01-init.sh`, root `package.json`, `CLAUDE.md`) — bewusst nicht mit eingecheckt.

Closes #85
Closes #86
Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
