### PR TITLE
Locale: Platzhalter-Konsistenz-Gate & Hardcoded-String-Migration (#90, #91)

### DIFF
--- a/.claude/skills/i18n-keys/SKILL.md
+++ b/.claude/skills/i18n-keys/SKILL.md
@@ -104,6 +104,18 @@ grep -rn "showError\|showSuccess\|toast.error\|alert(" frontend/src | grep -v "\
 
 Finds ggf. Strings wie `showError('Bitte ...')` die auf `$t(...)` umgestellt werden müssen.
 
+Auch **statische `aria-label` / `placeholder` / `title`** prüfen — sie leaken für Screenreader-User in der falschen Sprache:
+
+```bash
+grep -rnE "[^:](aria-label|placeholder|title)=\"[A-Za-zÄÖÜ]" frontend/src/components frontend/src/pages --include=*.vue
+```
+
+Treffer auf gebundene i18n-Ausdrücke umstellen (`:aria-label="$t('…')"`). Ausnahme: reine Marken-/Eigennamen (z. B. `ScoreCard`) bleiben unübersetzt.
+
+### Kein hartes Hardcoded-Gate (bewusste Entscheidung)
+
+Für hartkodierte Strings gibt es **absichtlich kein** durchsetzendes CI-Gate: die statische Erkennung kann user-facing nicht zuverlässig von technischen Strings (Log-Ausgaben, CSS-Klassen, Test-IDs) trennen — ein hartes Gate würde an False Positives ersticken. Der Audit oben ist der wiederholbare Weg; er wird vor „fertig" ausgeführt, nicht von der Pipeline erzwungen.
+
 ## Placeholder-Konvention
 
 User-facing Placeholder sollten Beispiele sein, keine Label-Duplikate:
@@ -120,10 +132,22 @@ Placeholder: "z.B. Sonntag im Eulachpark"
 
 ## Validation bei Adds
 
-Nach jedem Locale-Update:
+Key-Parität **und** Platzhalter-/Plural-Konsistenz sind als automatisches Gate
+durchgesetzt (Vitest, läuft im `unit-frontend`-Job):
 
 ```bash
-# Key-Konsistenz: haben alle 4 Locales denselben Key-Baum?
+npm run test --workspace=frontend   # schlägt fehl bei fehlenden/überzähligen Keys
+                                     # und bei abweichenden {platzhaltern}/Pluralen
+```
+
+Die Tests liegen in `frontend/src/locales/__tests__/` (`locale-parity.test.ts`,
+`locale-placeholders.test.ts`) und vergleichen alle Locales gegen `de.json`
+(Master). Fehlermeldungen listen pro Sprache konkret die fehlenden bzw.
+überzähligen Keys und die divergierenden Platzhalter auf.
+
+Schneller lokaler Ad-hoc-Check ohne Testlauf:
+
+```bash
 node -e "
 const locales = ['de', 'en', 'fr', 'nl'].map(l => require('./frontend/src/locales/' + l + '.json'))
 function keys(obj, prefix = '') {
@@ -137,11 +161,9 @@ function keys(obj, prefix = '') {
 }
 const [de, en, fr, nl] = locales.map(keys)
 const deSet = new Set(de)
-console.log('en missing:', en.filter(k => !deSet.has(k)).concat(de.filter(k => !new Set(en).has(k))))
+console.log('en diff:', en.filter(k => !deSet.has(k)).concat(de.filter(k => !new Set(en).has(k))))
 "
 ```
-
-Falls das skript etwas findet: in beiden Locales ergänzen / entfernen.
 
 ## Typische Fehler
 

--- a/frontend/src/components/games/GamesListCompact.vue
+++ b/frontend/src/components/games/GamesListCompact.vue
@@ -14,13 +14,13 @@
           class="field games-list-page__input"
           inputmode="search"
           autocomplete="off"
-          aria-label="Search games"
+          :aria-label="$t('Games.ListGames.SearchAria')"
         />
         <button
           v-if="searchTerm"
           @click="searchTerm = ''"
           class="games-list-page__clear"
-          aria-label="Clear search"
+          :aria-label="$t('Games.ListGames.ClearSearch')"
           type="button"
         >
           <XMarkIcon class="w-4 h-4" />

--- a/frontend/src/components/layout/TopBar.vue
+++ b/frontend/src/components/layout/TopBar.vue
@@ -12,7 +12,7 @@
           <ArrowLeftIcon class="w-5 h-5" />
         </AppIconButton>
 
-        <router-link v-else to="/" class="top-bar__brand" aria-label="ScoreCard Home">
+        <router-link v-else to="/" class="top-bar__brand" :aria-label="$t('General.BrandHome')">
           <img
             src="/img/web-app-manifest-192x192.png"
             alt=""
@@ -35,7 +35,7 @@
         </span>
 
         <!-- Desktop: quick links -->
-        <nav class="top-bar__desktop-nav" aria-label="Primary">
+        <nav class="top-bar__desktop-nav" :aria-label="$t('General.PrimaryNav')">
           <router-link
             v-for="item in desktopItems"
             :key="item.to"

--- a/frontend/src/components/ui/ScrollToTopButton.vue
+++ b/frontend/src/components/ui/ScrollToTopButton.vue
@@ -4,7 +4,7 @@
       v-if="showScrollToTop"
       @click="scrollToTop"
       class="scroll-top-btn"
-      aria-label="Nach oben"
+      :aria-label="$t('General.ScrollToTop')"
     >
       <ArrowUpIcon class="w-5 h-5" />
     </button>

--- a/frontend/src/components/ui/ToastContainer.vue
+++ b/frontend/src/components/ui/ToastContainer.vue
@@ -16,7 +16,7 @@
           <button
             @click="dismiss(toast.id)"
             class="toast__close"
-            aria-label="Dismiss notification"
+            :aria-label="$t('General.DismissNotification')"
           >&times;</button>
         </div>
       </TransitionGroup>

--- a/frontend/src/locales/__tests__/locale-placeholders.test.ts
+++ b/frontend/src/locales/__tests__/locale-placeholders.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import de from '@/locales/de.json'
+import en from '@/locales/en.json'
+import fr from '@/locales/fr.json'
+import nl from '@/locales/nl.json'
+
+type Json = Record<string, unknown>
+
+/** Flacht ein Locale-Objekt zu einer Map von Dot-Pfad-Key → String-Wert ab. */
+function flattenEntries(obj: Json, prefix = '', out: Map<string, string> = new Map()): Map<string, string> {
+  for (const [k, v] of Object.entries(obj)) {
+    const nk = prefix ? `${prefix}.${k}` : k
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      flattenEntries(v as Json, nk, out)
+    } else {
+      out.set(nk, String(v))
+    }
+  }
+  return out
+}
+
+/** Menge der benannten Interpolations-Platzhalter, z. B. "{n}", "{done}". */
+function placeholders(s: string): string[] {
+  return [...s.matchAll(/\{(\w+)\}/g)].map((m) => m[1]).sort()
+}
+
+/** Anzahl der Pluralzweige (vue-i18n trennt Pluralformen mit "|"). */
+function pluralBranches(s: string): number {
+  return s.split('|').length
+}
+
+const MASTER = 'de'
+const masterEntries = flattenEntries(de as Json)
+const locales: Record<string, Json> = { en, fr, nl }
+
+describe('Locale-Platzhalter-/Plural-Konsistenz', () => {
+  for (const [lang, dict] of Object.entries(locales)) {
+    it(`${lang}.json nutzt dieselben Platzhalter und Pluralstruktur wie ${MASTER}.json`, () => {
+      const entries = flattenEntries(dict)
+      const mismatches: string[] = []
+      for (const [key, masterVal] of masterEntries) {
+        const other = entries.get(key)
+        if (other === undefined) continue // Key-Parität deckt fehlende Keys ab
+        const a = placeholders(masterVal)
+        const b = placeholders(other)
+        if (a.join(',') !== b.join(',')) {
+          mismatches.push(`${key}: ${MASTER}{${a.join(',')}} ≠ ${lang}{${b.join(',')}}`)
+        }
+        if (pluralBranches(masterVal) !== pluralBranches(other)) {
+          mismatches.push(`${key}: Pluralzweige ${MASTER}=${pluralBranches(masterVal)} ${lang}=${pluralBranches(other)}`)
+        }
+      }
+      expect(mismatches, `${lang}.json — Platzhalter/Plural weichen von ${MASTER}.json ab`).toEqual([])
+    })
+  }
+
+  // Selbst-Verifikation der Prüf-Helfer.
+  it('placeholders extrahiert benannte Tokens sortiert und dedupliziert', () => {
+    expect(placeholders('Zum nächsten Loch ({n})')).toEqual(['n'])
+    expect(placeholders('{done} von {total}')).toEqual(['done', 'total'])
+    expect(placeholders('kein Text')).toEqual([])
+  })
+
+  it('erkennt abweichende Platzhalter zwischen zwei Werten', () => {
+    expect(placeholders('{done}/{total} erfasst').join(',')).not.toBe(
+      placeholders('{done} recorded').join(','),
+    )
+  })
+
+  it('pluralBranches zählt vue-i18n-Pluralzweige', () => {
+    expect(pluralBranches('ein Apfel | {n} Äpfel')).toBe(2)
+    expect(pluralBranches('nur ein Zweig')).toBe(1)
+  })
+})

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -17,7 +17,11 @@
     "FewerStrokes": "Weniger Schläge",
     "MoreStrokes": "Mehr Schläge",
     "Settings": "Einstellungen",
-    "Version": "Version"
+    "Version": "Version",
+    "ScrollToTop": "Nach oben",
+    "DismissNotification": "Benachrichtigung schließen",
+    "PrimaryNav": "Hauptnavigation",
+    "BrandHome": "ScoreCard Startseite"
   },
   "Settings": {
     "Theme": "Design",
@@ -152,6 +156,8 @@
       "NoGamesFound": "Keine Spiele gefunden",
       "HolesPlayed": "Gespielte Löcher",
       "SearchText": "Spiel- oder Spielername",
+      "SearchAria": "Spiele durchsuchen",
+      "ClearSearch": "Suche zurücksetzen",
       "LoadMore": "Weitere Spiele laden",
       "Loading": "Spiele werden geladen…"
     },
@@ -196,7 +202,9 @@
   "Sync": {
     "Offline": "Offline",
     "OfflinePending": "Offline · {n} ausstehend",
-    "Syncing": "Synchronisiere {n} …"
+    "Syncing": "Synchronisiere {n} …",
+    "Synced": "{n} Scores synchronisiert.",
+    "SyncFailed": "{n} Scores konnten nicht synchronisiert werden."
   },
   "Errors": {
     "RequestFailed": "Anfrage fehlgeschlagen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -17,7 +17,11 @@
     "FewerStrokes": "Fewer strokes",
     "MoreStrokes": "More strokes",
     "Settings": "Settings",
-    "Version": "Version"
+    "Version": "Version",
+    "ScrollToTop": "Back to top",
+    "DismissNotification": "Dismiss notification",
+    "PrimaryNav": "Main navigation",
+    "BrandHome": "ScoreCard home"
   },
   "Settings": {
     "Theme": "Theme",
@@ -152,6 +156,8 @@
       "NoGamesFound": "No games found",
       "HolesPlayed": "Holes Played",
       "SearchText": "Game- or Playername",
+      "SearchAria": "Search games",
+      "ClearSearch": "Clear search",
       "LoadMore": "Load more games",
       "Loading": "Loading games…"
     },
@@ -196,7 +202,9 @@
   "Sync": {
     "Offline": "Offline",
     "OfflinePending": "Offline · {n} pending",
-    "Syncing": "Syncing {n} …"
+    "Syncing": "Syncing {n} …",
+    "Synced": "{n} scores synced.",
+    "SyncFailed": "{n} scores couldn't be synced."
   },
   "Errors": {
     "RequestFailed": "Request failed",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -17,7 +17,11 @@
     "FewerStrokes": "Moins de coups",
     "MoreStrokes": "Plus de coups",
     "Settings": "Paramètres",
-    "Version": "Version"
+    "Version": "Version",
+    "ScrollToTop": "Vers le haut",
+    "DismissNotification": "Fermer la notification",
+    "PrimaryNav": "Navigation principale",
+    "BrandHome": "Accueil ScoreCard"
   },
   "Settings": {
     "Theme": "Thème",
@@ -152,6 +156,8 @@
       "NoGamesFound": "Aucune partie trouvée",
       "HolesPlayed": "Trous joués",
       "SearchText": "Nom du jeu ou du joueur",
+      "SearchAria": "Rechercher des parties",
+      "ClearSearch": "Effacer la recherche",
       "LoadMore": "Charger d'autres jeux",
       "Loading": "Chargement des parties…"
     },
@@ -196,7 +202,9 @@
   "Sync": {
     "Offline": "Hors ligne",
     "OfflinePending": "Hors ligne · {n} en attente",
-    "Syncing": "Synchronisation de {n} …"
+    "Syncing": "Synchronisation de {n} …",
+    "Synced": "{n} scores synchronisés.",
+    "SyncFailed": "{n} scores n'ont pas pu être synchronisés."
   },
   "Errors": {
     "RequestFailed": "Requête échouée",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -17,7 +17,11 @@
     "FewerStrokes": "Minder slagen",
     "MoreStrokes": "Meer slagen",
     "Settings": "Instellingen",
-    "Version": "Versie"
+    "Version": "Versie",
+    "ScrollToTop": "Naar boven",
+    "DismissNotification": "Melding sluiten",
+    "PrimaryNav": "Hoofdnavigatie",
+    "BrandHome": "ScoreCard startpagina"
   },
   "Settings": {
     "Theme": "Thema",
@@ -152,6 +156,8 @@
       "NoGamesFound": "Geen spellen gevonden",
       "HolesPlayed": "Gespeelde holes",
       "SearchText": "Spel- of spelersnaam",
+      "SearchAria": "Spellen zoeken",
+      "ClearSearch": "Zoekopdracht wissen",
       "LoadMore": "Meer spellen laden",
       "Loading": "Spellen worden geladen…"
     },
@@ -196,7 +202,9 @@
   "Sync": {
     "Offline": "Offline",
     "OfflinePending": "Offline · {n} in wachtrij",
-    "Syncing": "{n} synchroniseren …"
+    "Syncing": "{n} synchroniseren …",
+    "Synced": "{n} scores gesynchroniseerd.",
+    "SyncFailed": "{n} scores konden niet worden gesynchroniseerd."
   },
   "Errors": {
     "RequestFailed": "Verzoek mislukt",

--- a/frontend/src/stores/__tests__/scoreSync.test.ts
+++ b/frontend/src/stores/__tests__/scoreSync.test.ts
@@ -98,7 +98,7 @@ describe('useScoreSyncStore', () => {
 
       expect(mockApiSave).toHaveBeenCalledTimes(2)
       expect(queueStore.queue).toHaveLength(0)
-      expect(mockSuccess).toHaveBeenCalledWith('2 Score(s) synchronisiert.', 3000)
+      expect(mockSuccess).toHaveBeenCalledWith('Sync.Synced', 3000)
     })
 
     it('does nothing when offline', async () => {
@@ -132,8 +132,8 @@ describe('useScoreSyncStore', () => {
 
       expect(queueStore.queue).toHaveLength(1)
       expect(queueStore.queue[0].hole).toBe(2)
-      expect(mockSuccess).toHaveBeenCalledWith('1 Score(s) synchronisiert.', 3000)
-      expect(mockError).toHaveBeenCalledWith('1 Score(s) konnten nicht synchronisiert werden.', 6000)
+      expect(mockSuccess).toHaveBeenCalledWith('Sync.Synced', 3000)
+      expect(mockError).toHaveBeenCalledWith('Sync.SyncFailed', 6000)
     })
   })
 

--- a/frontend/src/stores/scoreSync.ts
+++ b/frontend/src/stores/scoreSync.ts
@@ -48,10 +48,10 @@ export const useScoreSyncStore = defineStore('scoreSync', () => {
     }
 
     if (successCount > 0) {
-      success(`${successCount} Score(s) synchronisiert.`, 3000)
+      success(t('Sync.Synced', { n: successCount }), 3000)
     }
     if (failCount > 0) {
-      error(`${failCount} Score(s) konnten nicht synchronisiert werden.`, 6000)
+      error(t('Sync.SyncFailed', { n: failCount }), 6000)
     }
   }
 


### PR DESCRIPTION
Setzt **#90** und **#91** (Slices 2 & 3 von PRD #84) um — zwei eigene Commits.

## #90 — Platzhalter-/Plural-Konsistenz-Gate
`5f…` *(Commit „Add locale placeholder & plural consistency gate")*
- Erweitert das Locale-Gate: für jeden über alle Sprachen geteilten Key müssen die benannten Platzhalter (`{n}`, `{done}`, …) identisch sein und die Plural-Zweig-Anzahl übereinstimmen.
- Fehlschlag mit pro-Sprache/pro-Key-Liste der Abweichungen. Läuft im `unit-frontend`-Gate.
- Bestand war bereits konsistent (kein Fixup). Prüf-Helfer via Fixtures selbst-verifiziert.

## #91 — Hardcoded-Strings migriert + Audit verankert
`69c9e95`
- **Audit** fand 6 user-facing Hardcoded-Strings, die eine feste Sprache leakten: die 2 Sync-Toasts in `scoreSync` (Deutsch, sichtbar) und 4 statische `aria-label`s (GamesListCompact Suche/Clear, ScrollToTopButton, Toast-Dismiss, TopBar Brand/Primary-Nav).
- Alle auf i18n-Keys umgestellt (`Sync.*`, `General.*`, `Games.ListGames.*`) und in de/en/fr/nl ergänzt — vom Paritäts- **und** Platzhalter-Gate validiert.
- **`i18n-keys`-Skill** um den wiederholbaren Audit (inkl. aria/placeholder/title-Sweep) erweitert und die **bewusste Entscheidung gegen ein hartes Hardcoded-CI-Gate** (zu viele False Positives) dokumentiert.

## Tests
`npm run test:all` grün: Lint · Type-Check · **110 Unit-Tests** · 40 Smoke-Tests. Der scoreSync-Store-Test wurde auf das i18n-Verhalten angepasst.

Closes #90
Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
