### PR TITLE
PRD #82: Spiel teilen (Link/QR), In-App-Scanner & Live-Polling (#94/#95/#96)

### DIFF
--- a/frontend/e2e/smoke/join-game.spec.ts
+++ b/frontend/e2e/smoke/join-game.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from './fixtures'
+
+test.describe('Spiel beitreten (Smoke)', () => {
+  const gameId = 'mock-game-alpha-2026'
+
+  test('manueller Fallback: Link einfügen führt ins Spiel', async ({ page, mockApi }) => {
+    void mockApi
+    await page.goto('/games')
+    await page.getByRole('button', { name: 'Spiel beitreten' }).click()
+
+    const sheet = page.locator('.sheet')
+    await expect(sheet).toBeVisible()
+
+    await sheet.locator('#join-manual').fill(`https://sc.urban-golf.ch/games/${gameId}`)
+    await sheet.getByRole('button', { name: 'Beitreten' }).click()
+
+    await expect(page).toHaveURL(new RegExp(`/games/${gameId}$`))
+    await expect(page.locator('.games-detail__title')).toContainText('Stadtpark-Runde')
+  })
+
+  test('ungültige Eingabe zeigt einen Fehlerhinweis', async ({ page, mockApi }) => {
+    void mockApi
+    await page.goto('/games')
+    await page.getByRole('button', { name: 'Spiel beitreten' }).click()
+
+    const sheet = page.locator('.sheet')
+    await sheet.locator('#join-manual').fill('nope')
+    await sheet.getByRole('button', { name: 'Beitreten' }).click()
+
+    await expect(sheet.getByText('Kein gültiger Spiel-Link.')).toBeVisible()
+    await expect(page).toHaveURL(/\/games$/)
+  })
+})

--- a/frontend/e2e/smoke/live-update.spec.ts
+++ b/frontend/e2e/smoke/live-update.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from './fixtures'
+
+test.describe('Live-Aktualisierung (Smoke)', () => {
+  const gameId = 'mock-game-alpha-2026'
+
+  test('Score-Änderung eines anderen Geräts erscheint automatisch', async ({ page, mockApi }) => {
+    await page.goto(`/games/${gameId}/1`)
+    const david = page.locator('.player-tile', { hasText: 'David Huber' })
+    await expect(david.locator('.stroke-value')).toHaveText('2')
+
+    // Ein anderes Gerät ändert Davids Loch 1 (Mutation am Mock-State)
+    const entry = mockApi.scores.find((s) => s.player_id === 'pl-david-huber-04' && s.hole === 1)!
+    entry.strokes = 12
+
+    // Nächster Poll übernimmt den neuen Wert (Intervall 4 s)
+    await expect(david.locator('.stroke-value')).toHaveText('12', { timeout: 8000 })
+  })
+
+  test('Zuschauer-Modus blendet alle Schreib-Einstiege aus', async ({ page, mockApi }) => {
+    void mockApi
+    await page.goto(`/games/${gameId}?spectator`)
+    await expect(page.locator('.games-detail__title')).toContainText('Stadtpark-Runde')
+    // Kein Teilen/Bearbeiten und keine Loch-Chips (die in die editierbare Hole-View führen)
+    await expect(page.locator('.games-detail__title-actions')).toHaveCount(0)
+    await expect(page.locator('.games-detail__holes')).toHaveCount(0)
+  })
+})

--- a/frontend/e2e/smoke/share-game.spec.ts
+++ b/frontend/e2e/smoke/share-game.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from './fixtures'
+
+test.describe('Spiel teilen (Smoke)', () => {
+  const gameId = 'mock-game-alpha-2026'
+
+  test('Teilen-Button öffnet Sheet mit Spiel-Link und kopiert ihn', async ({ page, context, mockApi }) => {
+    void mockApi
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    await page.goto(`/games/${gameId}`)
+    await page.getByRole('button', { name: 'Spiel teilen' }).click()
+
+    const sheet = page.locator('.sheet')
+    await expect(sheet).toBeVisible()
+
+    // Der angezeigte Link zeigt auf die Spielansicht dieses Spiels
+    await expect(sheet.locator('#share-link')).toHaveValue(new RegExp(`/games/${gameId}$`))
+
+    // Hinweis, dass jeder mit dem Link mitschreiben kann
+    await expect(sheet).toContainText('Link')
+
+    // Kopieren → Bestätigung "Kopiert!"
+    await sheet.getByRole('button', { name: 'Link kopieren' }).click()
+    await expect(sheet.getByText('Kopiert!')).toBeVisible()
+  })
+
+  test('geteilter Deep-Link führt direkt zur Spielansicht', async ({ page, mockApi }) => {
+    void mockApi
+    // Ein Beitretender öffnet den geteilten Link direkt
+    await page.goto(`/games/${gameId}`)
+    await expect(page.locator('.games-detail__title')).toContainText('Stadtpark-Runde')
+  })
+})

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -25,7 +25,8 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    # camera=(self): erlaubt den In-App-QR-Scanner (nur eigene Origin).
+    add_header Permissions-Policy "camera=(self), microphone=(), geolocation=()" always;
 
     # Cache static assets (1 Jahr – Vite-Assets haben Content-Hash im Dateinamen)
     location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot)$ {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@urban-golf/contract": "*",
     "@vueuse/core": "^14.0.0",
     "axios": "^1.15.2",
+    "jsqr": "^1.4.0",
     "marked": "^18.0.2",
     "nanoid": "^5.1.6",
     "pinia": "^3.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "marked": "^18.0.2",
     "nanoid": "^5.1.6",
     "pinia": "^3.0.4",
+    "qrcode": "^1.5.4",
     "vue": "^3.4.15",
     "vue-i18n": "^11.1.6",
     "vue-router": "^5.0.0"
@@ -37,6 +38,7 @@
     "@playwright/test": "^1.61.1",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.0.0",
+    "@types/qrcode": "^1.5.6",
     "@vitejs/plugin-vue": "^6.0.0",
     "eslint": "^10.0.0",
     "eslint-plugin-vue": "^10.0.0",

--- a/frontend/src/components/games/GamesHoleView.vue
+++ b/frontend/src/components/games/GamesHoleView.vue
@@ -207,6 +207,7 @@ import { useScoreSyncStore } from '@/stores/scoreSync'
 import { usePlayerColors } from '@/composables/usePlayerColors'
 import { useHoleCompletion } from '@/composables/useHoleCompletion'
 import { gamesDetailKey } from '@/types'
+import { scoreKey } from '@/utils/mergeScores'
 import { shortGameName } from '@/utils/format'
 import { VALIDATION } from '@/constants'
 import AppIconButton from '@/components/ui/AppIconButton.vue'
@@ -226,7 +227,7 @@ const gameId = computed(() => route.params.gameId as string)
 const hole = computed(() => parseInt(route.params.holeId as string))
 
 const context = inject(gamesDetailKey)!
-const { players, scores, holes, gameName } = context
+const { players, scores, holes, gameName, lockedScores } = context
 const { saveScore: saveScoreOffline } = useScoreSyncStore()
 const { colorMap } = usePlayerColors(players)
 const { hasScore, holeState } = useHoleCompletion(players, scores)
@@ -384,6 +385,9 @@ function changeStrokes(playerId: string, delta: number) {
 const savingMap = ref<Record<string, boolean>>({})
 
 async function saveScore(playerId: string) {
+  // Feld gegen Live-Overwrite sperren, solange gespeichert wird.
+  const lockKey = scoreKey(playerId, hole.value)
+  lockedScores.value.add(lockKey)
   savingMap.value[playerId] = true
   try {
     await saveScoreOffline({
@@ -400,6 +404,7 @@ async function saveScore(playerId: string) {
     }
   } finally {
     savingMap.value[playerId] = false
+    lockedScores.value.delete(lockKey)
   }
 }
 

--- a/frontend/src/components/games/GamesHoleView.vue
+++ b/frontend/src/components/games/GamesHoleView.vue
@@ -43,6 +43,14 @@
 
       <div class="hole-header__actions">
         <AppIconButton
+          :label="$t('Share.Title')"
+          variant="outline"
+          size="md"
+          @click="shareOpen = true"
+        >
+          <ShareIcon class="w-5 h-5" />
+        </AppIconButton>
+        <AppIconButton
           :label="$t('Games.HoleView.EditGame')"
           variant="outline"
           size="md"
@@ -186,6 +194,8 @@
         </details>
       </div>
     </AppBottomSheet>
+
+    <ShareGameSheet v-model="shareOpen" :game-id="gameId" :game-name="gameName" />
   </div>
 </template>
 
@@ -202,10 +212,11 @@ import { VALIDATION } from '@/constants'
 import AppIconButton from '@/components/ui/AppIconButton.vue'
 import AppBottomSheet from '@/components/ui/AppBottomSheet.vue'
 import PlayerAvatar from '@/components/ui/PlayerAvatar.vue'
+import ShareGameSheet from '@/components/games/ShareGameSheet.vue'
 import {
   MinusIcon, PlusIcon,
   ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon,
-  PencilSquareIcon, CheckIcon,
+  PencilSquareIcon, CheckIcon, ShareIcon,
 } from '@heroicons/vue/24/outline'
 
 const route = useRoute()
@@ -221,6 +232,7 @@ const { colorMap } = usePlayerColors(players)
 const { hasScore, holeState } = useHoleCompletion(players, scores)
 
 const displayName = computed(() => shortGameName(gameName.value))
+const shareOpen = ref(false)
 
 function hasCurrentScore(playerId: string) {
   return hasScore(playerId, hole.value)
@@ -500,6 +512,13 @@ function ensureScoreFieldsExist() {
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
+}
+
+.hole-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
 }
 
 .hole-header__title {

--- a/frontend/src/components/games/GamesListCompact.vue
+++ b/frontend/src/components/games/GamesListCompact.vue
@@ -1,7 +1,17 @@
 <template>
   <div class="container-app games-list-page">
     <header class="games-list-page__header">
-      <h1 class="t-headline">{{ $t('Games.ListGames.AllGames') }}</h1>
+      <div class="games-list-page__title-row">
+        <h1 class="t-headline">{{ $t('Games.ListGames.AllGames') }}</h1>
+        <AppIconButton
+          :label="$t('Join.Title')"
+          variant="outline"
+          size="md"
+          @click="joinOpen = true"
+        >
+          <QrCodeIcon class="w-5 h-5" />
+        </AppIconButton>
+      </div>
 
       <div class="games-list-page__search">
         <span class="games-list-page__search-icon" aria-hidden="true">
@@ -38,13 +48,17 @@
         </div>
       </template>
     </Suspense>
+
+    <JoinGameSheet v-model="joinOpen" />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import GamesListCompactContent from '@/components/games/GamesListCompactContent.vue'
-import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/vue/24/outline'
+import JoinGameSheet from '@/components/games/JoinGameSheet.vue'
+import AppIconButton from '@/components/ui/AppIconButton.vue'
+import { MagnifyingGlassIcon, XMarkIcon, QrCodeIcon } from '@heroicons/vue/24/outline'
 
 function calculatePerPage(): number {
   const available = typeof window !== 'undefined' ? window.innerHeight - 320 : 600
@@ -53,6 +67,7 @@ function calculatePerPage(): number {
 
 const searchTerm = ref('')
 const perPage = ref(calculatePerPage())
+const joinOpen = ref(false)
 
 function handleResize() { perPage.value = calculatePerPage() }
 
@@ -72,6 +87,13 @@ onUnmounted(() => { window.removeEventListener('resize', handleResize) })
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
+}
+
+.games-list-page__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
 .games-list-page__search {

--- a/frontend/src/components/games/JoinGameSheet.vue
+++ b/frontend/src/components/games/JoinGameSheet.vue
@@ -1,0 +1,177 @@
+<template>
+  <AppBottomSheet
+    :model-value="modelValue"
+    :label="$t('Join.Title')"
+    :title="$t('Join.Title')"
+    @update:model-value="onSheet"
+  >
+    <div class="join">
+      <div class="join__scanner" :class="{ 'is-active': scanning }">
+        <video ref="videoRef" class="join__video" playsinline muted></video>
+        <div v-if="!scanning" class="join__placeholder">
+          <QrCodeIcon class="join__placeholder-icon" aria-hidden="true" />
+        </div>
+      </div>
+
+      <AppButton v-if="!scanning" variant="primary" size="lg" block pill @click="startScan">
+        <template #icon-left>
+          <CameraIcon class="w-5 h-5" />
+        </template>
+        {{ $t('Join.StartCamera') }}
+      </AppButton>
+      <AppButton v-else variant="secondary" size="lg" block pill @click="stop">
+        {{ $t('Join.StopCamera') }}
+      </AppButton>
+
+      <p v-if="error === 'denied'" class="join__hint">{{ $t('Join.CameraDenied') }}</p>
+      <p v-else-if="error === 'unsupported'" class="join__hint">{{ $t('Join.CameraUnsupported') }}</p>
+
+      <label class="t-eyebrow join__label" for="join-manual">{{ $t('Join.ManualLabel') }}</label>
+      <div class="join__manual">
+        <input
+          id="join-manual"
+          v-model="manual"
+          class="field join__manual-input"
+          type="text"
+          :placeholder="$t('Join.ManualPlaceholder')"
+          @keydown.enter="submitManual"
+          @input="invalid = false"
+        />
+        <AppButton variant="secondary" size="md" pill @click="submitManual">
+          {{ $t('Join.Submit') }}
+        </AppButton>
+      </div>
+      <p v-if="invalid" class="join__hint join__hint--error" role="alert">{{ $t('Join.InvalidRef') }}</p>
+    </div>
+  </AppBottomSheet>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { CameraIcon, QrCodeIcon } from '@heroicons/vue/24/outline'
+import AppBottomSheet from '@/components/ui/AppBottomSheet.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import { useQrScanner } from '@/composables/useQrScanner'
+import { parseGameRef } from '@/utils/gameRef'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits<{ 'update:modelValue': [value: boolean] }>()
+
+const router = useRouter()
+const videoRef = ref<HTMLVideoElement | null>(null)
+const manual = ref('')
+const invalid = ref(false)
+
+const { scanning, error, start, stop } = useQrScanner(onDecoded)
+
+function onDecoded(text: string) {
+  const id = parseGameRef(text)
+  if (id) join(id)
+  else invalid.value = true
+}
+
+async function startScan() {
+  invalid.value = false
+  if (videoRef.value) await start(videoRef.value)
+}
+
+function submitManual() {
+  const id = parseGameRef(manual.value)
+  if (id) join(id)
+  else invalid.value = true
+}
+
+function join(id: string) {
+  stop()
+  emit('update:modelValue', false)
+  void router.push(`/games/${id}`)
+}
+
+function onSheet(open: boolean) {
+  if (!open) stop()
+  emit('update:modelValue', open)
+}
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (!open) {
+      stop()
+      invalid.value = false
+      manual.value = ''
+    }
+  },
+)
+</script>
+
+<style scoped>
+.join {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding-bottom: 0.25rem;
+}
+
+.join__scanner {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  max-height: 15rem;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: color-mix(in oklab, var(--text-default) 8%, transparent);
+  border: 1px solid var(--card-border);
+}
+
+.join__video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: none;
+}
+
+.join__scanner.is-active .join__video {
+  display: block;
+}
+
+.join__placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.join__placeholder-icon {
+  width: 3.5rem;
+  height: 3.5rem;
+  opacity: 0.5;
+}
+
+.join__hint {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.join__hint--error {
+  color: var(--color-danger-500);
+  font-weight: 600;
+}
+
+.join__label {
+  margin: 0.35rem 0 -0.35rem;
+}
+
+.join__manual {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.join__manual-input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+</style>

--- a/frontend/src/components/games/ShareGameSheet.vue
+++ b/frontend/src/components/games/ShareGameSheet.vue
@@ -1,0 +1,122 @@
+<template>
+  <AppBottomSheet
+    :model-value="modelValue"
+    :label="$t('Share.Title')"
+    :title="$t('Share.Title')"
+    @update:model-value="v => emit('update:modelValue', v)"
+  >
+    <div class="share">
+      <!-- Transparenz: jeder mit dem Link kann mitschreiben -->
+      <p class="share__notice">
+        <InformationCircleIcon class="share__notice-icon" aria-hidden="true" />
+        <span>{{ $t('Share.EditWarning') }}</span>
+      </p>
+
+      <label class="t-eyebrow share__label" for="share-link">{{ $t('Share.LinkLabel') }}</label>
+      <input
+        id="share-link"
+        class="field share__link"
+        type="text"
+        :value="shareUrl"
+        readonly
+        @focus="selectAll"
+      />
+
+      <div class="share__actions">
+        <AppButton variant="secondary" size="lg" block pill @click="onCopy">
+          <template #icon-left>
+            <CheckIcon v-if="copied" class="w-5 h-5" />
+            <ClipboardDocumentIcon v-else class="w-5 h-5" />
+          </template>
+          {{ copied ? $t('Share.Copied') : $t('Share.Copy') }}
+        </AppButton>
+
+        <AppButton v-if="canNativeShare" variant="primary" size="lg" block pill @click="onShare">
+          <template #icon-left>
+            <ShareIcon class="w-5 h-5" />
+          </template>
+          {{ $t('Share.Share') }}
+        </AppButton>
+      </div>
+    </div>
+  </AppBottomSheet>
+</template>
+
+<script setup lang="ts">
+import { toRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  InformationCircleIcon,
+  ClipboardDocumentIcon,
+  CheckIcon,
+  ShareIcon,
+} from '@heroicons/vue/24/outline'
+import AppBottomSheet from '@/components/ui/AppBottomSheet.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import { useShareGame } from '@/composables/useShareGame'
+
+const props = defineProps<{ modelValue: boolean; gameId: string; gameName: string }>()
+const emit = defineEmits<{ 'update:modelValue': [value: boolean] }>()
+
+const { t } = useI18n()
+const { shareUrl, canNativeShare, copied, copyLink, nativeShare } = useShareGame(toRef(props, 'gameId'))
+
+function onCopy() {
+  void copyLink()
+}
+
+function onShare() {
+  void nativeShare(props.gameName || t('Share.Title'))
+}
+
+function selectAll(e: FocusEvent) {
+  ;(e.target as HTMLInputElement).select()
+}
+</script>
+
+<style scoped>
+.share {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding-bottom: 0.25rem;
+}
+
+.share__notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  color: var(--text-default);
+  font-size: var(--text-sm);
+}
+
+.share__notice-icon {
+  width: 1.15rem;
+  height: 1.15rem;
+  flex-shrink: 0;
+  color: var(--primary);
+  margin-top: 0.05rem;
+}
+
+.share__label {
+  margin: 0.15rem 0 -0.35rem;
+}
+
+.share__link {
+  width: 100%;
+  font-size: var(--text-sm);
+  color: var(--text-default);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.share__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+</style>

--- a/frontend/src/components/games/ShareGameSheet.vue
+++ b/frontend/src/components/games/ShareGameSheet.vue
@@ -12,6 +12,18 @@
         <span>{{ $t('Share.EditWarning') }}</span>
       </p>
 
+      <!-- QR-Code: Mitspieler scannt mit dem Handy und ist sofort im Spiel -->
+      <figure v-if="qrDataUrl" class="share__qr">
+        <img
+          :src="qrDataUrl"
+          class="share__qr-img"
+          :alt="$t('Share.QrAlt')"
+          width="200"
+          height="200"
+        />
+        <figcaption class="share__qr-hint">{{ $t('Share.ScanHint') }}</figcaption>
+      </figure>
+
       <label class="t-eyebrow share__label" for="share-link">{{ $t('Share.LinkLabel') }}</label>
       <input
         id="share-link"
@@ -54,12 +66,14 @@ import {
 import AppBottomSheet from '@/components/ui/AppBottomSheet.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import { useShareGame } from '@/composables/useShareGame'
+import { useQrCode } from '@/composables/useQrCode'
 
 const props = defineProps<{ modelValue: boolean; gameId: string; gameName: string }>()
 const emit = defineEmits<{ 'update:modelValue': [value: boolean] }>()
 
 const { t } = useI18n()
 const { shareUrl, canNativeShare, copied, copyLink, nativeShare } = useShareGame(toRef(props, 'gameId'))
+const { dataUrl: qrDataUrl } = useQrCode(shareUrl)
 
 function onCopy() {
   void copyLink()
@@ -99,6 +113,31 @@ function selectAll(e: FocusEvent) {
   flex-shrink: 0;
   color: var(--primary);
   margin-top: 0.05rem;
+}
+
+.share__qr {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.15rem 0 0.35rem;
+}
+
+.share__qr-img {
+  width: 200px;
+  height: 200px;
+  max-width: 60vw;
+  max-height: 60vw;
+  border-radius: var(--radius-md);
+  background: #fff;
+  padding: 0.5rem;
+  box-shadow: var(--shadow-elev-1);
+}
+
+.share__qr-hint {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 600;
 }
 
 .share__label {

--- a/frontend/src/composables/__tests__/useQrCode.test.ts
+++ b/frontend/src/composables/__tests__/useQrCode.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ref, nextTick } from 'vue'
+
+const toDataURL = vi.fn()
+vi.mock('qrcode', () => ({ default: { toDataURL: (...a: unknown[]) => toDataURL(...a) } }))
+
+import { useQrCode } from '../useQrCode'
+
+describe('useQrCode', () => {
+  it('generates a data URL from the text', async () => {
+    toDataURL.mockResolvedValue('data:image/png;base64,ABC')
+    const text = ref('https://sc.urban-golf.ch/games/game1234567890')
+    const { dataUrl } = useQrCode(text)
+    await nextTick()
+    await Promise.resolve()
+    expect(toDataURL).toHaveBeenCalledWith(text.value, expect.objectContaining({ margin: 1 }))
+    expect(dataUrl.value).toBe('data:image/png;base64,ABC')
+  })
+
+  it('regenerates when the text changes', async () => {
+    toDataURL.mockResolvedValue('data:image/png;base64,ONE')
+    const text = ref('https://sc.urban-golf.ch/games/aaaaaaaaaa')
+    const { dataUrl } = useQrCode(text)
+    await Promise.resolve()
+    toDataURL.mockResolvedValue('data:image/png;base64,TWO')
+    text.value = 'https://sc.urban-golf.ch/games/bbbbbbbbbb'
+    await nextTick()
+    await Promise.resolve()
+    expect(dataUrl.value).toBe('data:image/png;base64,TWO')
+  })
+
+  it('sets failed and clears the url when generation throws', async () => {
+    toDataURL.mockRejectedValue(new Error('boom'))
+    const { dataUrl, failed } = useQrCode(ref('x'))
+    await nextTick()
+    await Promise.resolve()
+    expect(dataUrl.value).toBe('')
+    expect(failed.value).toBe(true)
+  })
+
+  it('produces no url for empty text', async () => {
+    const { dataUrl } = useQrCode(ref(''))
+    await nextTick()
+    expect(dataUrl.value).toBe('')
+  })
+})

--- a/frontend/src/composables/__tests__/useShareGame.test.ts
+++ b/frontend/src/composables/__tests__/useShareGame.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+import { useShareGame } from '../useShareGame'
+
+describe('useShareGame', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', { location: { origin: 'https://sc.urban-golf.ch' } })
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('builds the share URL from the origin and game id', () => {
+    const { shareUrl } = useShareGame(ref('mock-game-alpha-2026'))
+    expect(shareUrl.value).toBe('https://sc.urban-golf.ch/games/mock-game-alpha-2026')
+  })
+
+  it('copyLink writes the URL to the clipboard and toggles copied', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+    const { copyLink, copied } = useShareGame(ref('game1234567890'))
+
+    expect(copied.value).toBe(false)
+    const ok = await copyLink()
+    expect(ok).toBe(true)
+    expect(writeText).toHaveBeenCalledWith('https://sc.urban-golf.ch/games/game1234567890')
+    expect(copied.value).toBe(true)
+  })
+
+  it('copyLink returns false when the clipboard write fails', async () => {
+    vi.stubGlobal('navigator', {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+    })
+    const { copyLink, copied } = useShareGame(ref('game1234567890'))
+    expect(await copyLink()).toBe(false)
+    expect(copied.value).toBe(false)
+  })
+
+  it('nativeShare uses the Web Share API when available', async () => {
+    const share = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { share })
+    const { nativeShare, canNativeShare } = useShareGame(ref('game1234567890'))
+    expect(canNativeShare.value).toBe(true)
+    await nativeShare('Stadtpark-Runde')
+    expect(share).toHaveBeenCalledWith({
+      title: 'Stadtpark-Runde',
+      url: 'https://sc.urban-golf.ch/games/game1234567890',
+    })
+  })
+
+  it('nativeShare falls back to clipboard when Web Share API is missing', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+    const { nativeShare, canNativeShare } = useShareGame(ref('game1234567890'))
+    expect(canNativeShare.value).toBe(false)
+    await nativeShare('Stadtpark-Runde')
+    expect(writeText).toHaveBeenCalledWith('https://sc.urban-golf.ch/games/game1234567890')
+  })
+
+  it('nativeShare swallows a user cancellation without throwing', async () => {
+    const share = vi.fn().mockRejectedValue(new DOMException('cancelled', 'AbortError'))
+    vi.stubGlobal('navigator', { share })
+    const { nativeShare } = useShareGame(ref('game1234567890'))
+    await expect(nativeShare('Stadtpark-Runde')).resolves.toBeUndefined()
+  })
+})

--- a/frontend/src/composables/useLivePolling.ts
+++ b/frontend/src/composables/useLivePolling.ts
@@ -1,0 +1,61 @@
+import { onMounted, onBeforeUnmount } from 'vue'
+
+/**
+ * Ruft `poll` in einem Intervall auf, solange die Seite sichtbar ist.
+ * Pausiert bei verstecktem Tab / Hintergrund-App (Page Visibility) und nimmt
+ * bei Sichtbarkeit wieder auf. Fehlgeschlagene Poll-Versuche werden still
+ * verschluckt — kein Fehler-Spam bei schlechter Verbindung.
+ */
+export function useLivePolling(poll: () => Promise<void>, intervalMs = 5000) {
+  let timer: ReturnType<typeof setInterval> | undefined
+
+  function isVisible(): boolean {
+    return typeof document === 'undefined' || document.visibilityState === 'visible'
+  }
+
+  async function runOnce() {
+    if (!isVisible()) return
+    try {
+      await poll()
+    } catch {
+      /* still: keine Toast-Flut bei fehlgeschlagenen Updates */
+    }
+  }
+
+  function startTimer() {
+    if (timer) return
+    timer = setInterval(() => void runOnce(), intervalMs)
+  }
+
+  function stopTimer() {
+    if (timer) {
+      clearInterval(timer)
+      timer = undefined
+    }
+  }
+
+  function onVisibilityChange() {
+    if (isVisible()) {
+      void runOnce()
+      startTimer()
+    } else {
+      stopTimer()
+    }
+  }
+
+  onMounted(() => {
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVisibilityChange)
+    }
+    if (isVisible()) startTimer()
+  })
+
+  onBeforeUnmount(() => {
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+    stopTimer()
+  })
+
+  return { runOnce }
+}

--- a/frontend/src/composables/useQrCode.ts
+++ b/frontend/src/composables/useQrCode.ts
@@ -1,0 +1,30 @@
+import { ref, watch, type Ref } from 'vue'
+import QRCode from 'qrcode'
+
+/**
+ * Erzeugt clientseitig einen QR-Code als data:-URL (PNG) aus einem Text.
+ * data:-Bilder sind CSP-konform (kein externer Request) und lassen sich
+ * direkt in ein <img> hängen.
+ */
+export function useQrCode(text: Ref<string>) {
+  const dataUrl = ref('')
+  const failed = ref(false)
+
+  async function generate(value: string) {
+    if (!value) {
+      dataUrl.value = ''
+      return
+    }
+    try {
+      dataUrl.value = await QRCode.toDataURL(value, { margin: 1, width: 240 })
+      failed.value = false
+    } catch {
+      dataUrl.value = ''
+      failed.value = true
+    }
+  }
+
+  watch(text, (v) => void generate(v), { immediate: true })
+
+  return { dataUrl, failed }
+}

--- a/frontend/src/composables/useQrScanner.ts
+++ b/frontend/src/composables/useQrScanner.ts
@@ -1,0 +1,84 @@
+import { ref, onBeforeUnmount } from 'vue'
+import jsQR from 'jsqr'
+
+export type ScannerError = 'denied' | 'unsupported' | null
+
+/**
+ * Liest QR-Codes über die Gerätekamera. Die Kamera läuft nur zwischen
+ * start() und stop()/Fund — danach werden alle Tracks sofort freigegeben.
+ * Der Decode-Loop läuft über ein Offscreen-Canvas + jsQR.
+ */
+export function useQrScanner(onDecode: (text: string) => void) {
+  const scanning = ref(false)
+  const error = ref<ScannerError>(null)
+
+  let stream: MediaStream | null = null
+  let rafId = 0
+  let video: HTMLVideoElement | null = null
+  let canvas: HTMLCanvasElement | null = null
+
+  async function start(videoEl: HTMLVideoElement): Promise<void> {
+    error.value = null
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      error.value = 'unsupported'
+      return
+    }
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } })
+    } catch {
+      error.value = 'denied'
+      return
+    }
+    video = videoEl
+    video.srcObject = stream
+    try {
+      await video.play()
+    } catch {
+      /* Autoplay-Restriktion — der Frame-Loop wartet ohnehin auf Daten. */
+    }
+    canvas = document.createElement('canvas')
+    scanning.value = true
+    tick()
+  }
+
+  function tick(): void {
+    if (!scanning.value || !video || !canvas) return
+    if (video.readyState >= 2 && video.videoWidth > 0) {
+      const w = video.videoWidth
+      const h = video.videoHeight
+      canvas.width = w
+      canvas.height = h
+      const ctx = canvas.getContext('2d', { willReadFrequently: true })
+      if (ctx) {
+        ctx.drawImage(video, 0, 0, w, h)
+        const frame = ctx.getImageData(0, 0, w, h)
+        const result = jsQR(frame.data, w, h)
+        if (result?.data) {
+          stop()
+          onDecode(result.data)
+          return
+        }
+      }
+    }
+    rafId = requestAnimationFrame(tick)
+  }
+
+  function stop(): void {
+    scanning.value = false
+    if (rafId) cancelAnimationFrame(rafId)
+    rafId = 0
+    if (stream) {
+      stream.getTracks().forEach((t) => t.stop())
+      stream = null
+    }
+    if (video) {
+      video.srcObject = null
+      video = null
+    }
+    canvas = null
+  }
+
+  onBeforeUnmount(stop)
+
+  return { scanning, error, start, stop }
+}

--- a/frontend/src/composables/useShareGame.ts
+++ b/frontend/src/composables/useShareGame.ts
@@ -1,0 +1,55 @@
+import { ref, computed, type Ref } from 'vue'
+
+/**
+ * Teilen-Logik für ein Spiel: erzeugt den Share-Link auf die Spielansicht,
+ * bietet natives Teilen (Web Share API) mit Clipboard-Copy als Fallback.
+ *
+ * Das Modell ist bewusst anonym — jeder mit dem Link kann das Spiel öffnen
+ * und Scores eintragen. Zugriffskontrolle ist nicht Teil dieses Features.
+ */
+export function useShareGame(gameId: Ref<string>) {
+  const shareUrl = computed(() => {
+    const origin = typeof window !== 'undefined' ? window.location.origin : ''
+    return `${origin}/games/${gameId.value}`
+  })
+
+  const canNativeShare = computed(
+    () => typeof navigator !== 'undefined' && typeof navigator.share === 'function',
+  )
+
+  const copied = ref(false)
+  let copyTimer: ReturnType<typeof setTimeout> | undefined
+
+  async function copyLink(): Promise<boolean> {
+    try {
+      await navigator.clipboard.writeText(shareUrl.value)
+      copied.value = true
+      if (copyTimer) clearTimeout(copyTimer)
+      copyTimer = setTimeout(() => {
+        copied.value = false
+      }, 2000)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Öffnet das native Share-Sheet. Ohne Web Share API (z. B. Desktop) fällt
+   * die Funktion auf Clipboard-Copy zurück. Ein Abbruch durch den Nutzer wird
+   * bewusst verschluckt — kein Fehler-Toast.
+   */
+  async function nativeShare(title: string): Promise<void> {
+    if (!canNativeShare.value) {
+      await copyLink()
+      return
+    }
+    try {
+      await navigator.share({ title, url: shareUrl.value })
+    } catch {
+      /* Nutzer hat abgebrochen oder Teilen fehlgeschlagen — ignorieren. */
+    }
+  }
+
+  return { shareUrl, canNativeShare, copied, copyLink, nativeShare }
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -125,7 +125,9 @@
     "LinkLabel": "Spiel-Link",
     "Copy": "Link kopieren",
     "Copied": "Kopiert!",
-    "Share": "Teilen"
+    "Share": "Teilen",
+    "ScanHint": "Zum Beitreten scannen",
+    "QrAlt": "QR-Code zum Spiel-Link"
   },
   "Feedback": {
     "Title": "Feedback zur Scorecard",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -129,6 +129,17 @@
     "ScanHint": "Zum Beitreten scannen",
     "QrAlt": "QR-Code zum Spiel-Link"
   },
+  "Join": {
+    "Title": "Spiel beitreten",
+    "StartCamera": "Kamera starten",
+    "StopCamera": "Kamera stoppen",
+    "ManualLabel": "Oder Link/ID einfügen",
+    "ManualPlaceholder": "Link oder Spiel-ID",
+    "Submit": "Beitreten",
+    "InvalidRef": "Kein gültiger Spiel-Link.",
+    "CameraDenied": "Kein Kamerazugriff. Gib den Link stattdessen manuell ein.",
+    "CameraUnsupported": "Kamera nicht verfügbar. Gib den Link stattdessen manuell ein."
+  },
   "Feedback": {
     "Title": "Feedback zur Scorecard",
     "Subtitle": "Was können wir besser machen? Jedes Feedback hilft.",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -119,6 +119,14 @@
       }
     }
   },
+  "Share": {
+    "Title": "Spiel teilen",
+    "EditWarning": "Jeder mit diesem Link kann Scores eintragen.",
+    "LinkLabel": "Spiel-Link",
+    "Copy": "Link kopieren",
+    "Copied": "Kopiert!",
+    "Share": "Teilen"
+  },
   "Feedback": {
     "Title": "Feedback zur Scorecard",
     "Subtitle": "Was können wir besser machen? Jedes Feedback hilft.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -129,6 +129,17 @@
     "ScanHint": "Scan to join",
     "QrAlt": "QR code for the game link"
   },
+  "Join": {
+    "Title": "Join game",
+    "StartCamera": "Start camera",
+    "StopCamera": "Stop camera",
+    "ManualLabel": "Or paste a link/ID",
+    "ManualPlaceholder": "Link or game ID",
+    "Submit": "Join",
+    "InvalidRef": "Not a valid game link.",
+    "CameraDenied": "No camera access. Enter the link manually instead.",
+    "CameraUnsupported": "Camera not available. Enter the link manually instead."
+  },
   "Feedback": {
     "Title": "Feedback on the Scorecard",
     "Subtitle": "How can we improve? Every piece of feedback helps.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -119,6 +119,14 @@
       }
     }
   },
+  "Share": {
+    "Title": "Share game",
+    "EditWarning": "Anyone with this link can enter scores.",
+    "LinkLabel": "Game link",
+    "Copy": "Copy link",
+    "Copied": "Copied!",
+    "Share": "Share"
+  },
   "Feedback": {
     "Title": "Feedback on the Scorecard",
     "Subtitle": "How can we improve? Every piece of feedback helps.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -125,7 +125,9 @@
     "LinkLabel": "Game link",
     "Copy": "Copy link",
     "Copied": "Copied!",
-    "Share": "Share"
+    "Share": "Share",
+    "ScanHint": "Scan to join",
+    "QrAlt": "QR code for the game link"
   },
   "Feedback": {
     "Title": "Feedback on the Scorecard",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -129,6 +129,17 @@
     "ScanHint": "Scanner pour rejoindre",
     "QrAlt": "QR code du lien de la partie"
   },
+  "Join": {
+    "Title": "Rejoindre la partie",
+    "StartCamera": "Démarrer la caméra",
+    "StopCamera": "Arrêter la caméra",
+    "ManualLabel": "Ou collez un lien/ID",
+    "ManualPlaceholder": "Lien ou ID de partie",
+    "Submit": "Rejoindre",
+    "InvalidRef": "Lien de partie invalide.",
+    "CameraDenied": "Pas d'accès à la caméra. Saisissez le lien manuellement.",
+    "CameraUnsupported": "Caméra indisponible. Saisissez le lien manuellement."
+  },
   "Feedback": {
     "Title": "Retour sur la scorecard",
     "Subtitle": "Comment pouvons-nous faire mieux ? Chaque retour aide.",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -125,7 +125,9 @@
     "LinkLabel": "Lien de la partie",
     "Copy": "Copier le lien",
     "Copied": "Copié !",
-    "Share": "Partager"
+    "Share": "Partager",
+    "ScanHint": "Scanner pour rejoindre",
+    "QrAlt": "QR code du lien de la partie"
   },
   "Feedback": {
     "Title": "Retour sur la scorecard",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -119,6 +119,14 @@
       }
     }
   },
+  "Share": {
+    "Title": "Partager la partie",
+    "EditWarning": "Toute personne disposant de ce lien peut saisir des scores.",
+    "LinkLabel": "Lien de la partie",
+    "Copy": "Copier le lien",
+    "Copied": "Copié !",
+    "Share": "Partager"
+  },
   "Feedback": {
     "Title": "Retour sur la scorecard",
     "Subtitle": "Comment pouvons-nous faire mieux ? Chaque retour aide.",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -119,6 +119,14 @@
       }
     }
   },
+  "Share": {
+    "Title": "Spel delen",
+    "EditWarning": "Iedereen met deze link kan scores invoeren.",
+    "LinkLabel": "Spellink",
+    "Copy": "Link kopiëren",
+    "Copied": "Gekopieerd!",
+    "Share": "Delen"
+  },
   "Feedback": {
     "Title": "Feedback over de scorecard",
     "Subtitle": "Wat kunnen we beter doen? Alle feedback helpt.",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -129,6 +129,17 @@
     "ScanHint": "Scan om mee te doen",
     "QrAlt": "QR-code voor de spellink"
   },
+  "Join": {
+    "Title": "Deelnemen aan spel",
+    "StartCamera": "Camera starten",
+    "StopCamera": "Camera stoppen",
+    "ManualLabel": "Of plak een link/ID",
+    "ManualPlaceholder": "Link of spel-ID",
+    "Submit": "Deelnemen",
+    "InvalidRef": "Geen geldige spellink.",
+    "CameraDenied": "Geen cameratoegang. Voer de link handmatig in.",
+    "CameraUnsupported": "Camera niet beschikbaar. Voer de link handmatig in."
+  },
   "Feedback": {
     "Title": "Feedback over de scorecard",
     "Subtitle": "Wat kunnen we beter doen? Alle feedback helpt.",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -125,7 +125,9 @@
     "LinkLabel": "Spellink",
     "Copy": "Link kopiëren",
     "Copied": "Gekopieerd!",
-    "Share": "Delen"
+    "Share": "Delen",
+    "ScanHint": "Scan om mee te doen",
+    "QrAlt": "QR-code voor de spellink"
   },
   "Feedback": {
     "Title": "Feedback over de scorecard",

--- a/frontend/src/pages/games/GamesPage.vue
+++ b/frontend/src/pages/games/GamesPage.vue
@@ -15,7 +15,7 @@
               <h1 class="t-title games-detail__title" :title="gameName">
                 {{ displayName }}
               </h1>
-              <div class="games-detail__title-actions">
+              <div v-if="!isSpectator" class="games-detail__title-actions">
                 <AppIconButton
                   :label="$t('Share.Title')"
                   variant="outline"
@@ -35,8 +35,9 @@
               </div>
             </div>
 
-            <!-- Direkter Loch-Zugriff: Chip-Leiste zum Springen in die Hole-View. -->
-            <div v-if="holes.length" class="games-detail__holes scroll-hide" role="list">
+            <!-- Direkter Loch-Zugriff: Chip-Leiste zum Springen in die Hole-View.
+                 Im Zuschauer-Modus ausgeblendet (kein Schreib-Einstieg). -->
+            <div v-if="holes.length && !isSpectator" class="games-detail__holes scroll-hide" role="list">
               <router-link
                 v-for="n in holes"
                 :key="n"
@@ -86,7 +87,10 @@ import { useRoute } from 'vue-router'
 
 import { useGamesDetailData } from '@/composables/useGamesDetailData'
 import { useHoleCompletion } from '@/composables/useHoleCompletion'
-import { gamesDetailKey } from '@/types'
+import { useLivePolling } from '@/composables/useLivePolling'
+import { fetchScores } from '@/services/api'
+import { gamesDetailKey, type ScoreMap } from '@/types'
+import { mergeServerScores, scoresToMap } from '@/utils/mergeScores'
 import { shortGameName } from '@/utils/format'
 import { VALIDATION } from '@/constants'
 
@@ -98,12 +102,39 @@ const hasValidGameId = computed(() =>
   typeof gameId.value === 'string' && /^[a-zA-Z0-9_-]{10,30}$/.test(gameId.value)
 )
 const isHoleView = computed(() => 'holeId' in route.params)
+// Read-only-Zuschauer: ?spectator blendet alle Schreib-Einstiege aus.
+const isSpectator = computed(() => route.query.spectator !== undefined)
 
 const { players, scores, holes, gameName, error, load: loadGamesDetailData } = useGamesDetailData(gameId)
+const lockedScores = ref<Set<string>>(new Set())
 
-provide(gamesDetailKey, { players, scores, holes, gameName, error, load: loadGamesDetailData })
+provide(gamesDetailKey, { players, scores, holes, gameName, error, load: loadGamesDetailData, lockedScores })
 
 const { holeState } = useHoleCompletion(players, scores)
+
+// ---- Live-Aktualisierung per Polling ----
+function cloneScores(s: ScoreMap): ScoreMap {
+  const out: ScoreMap = {}
+  for (const pid in s) out[pid] = { ...s[pid] }
+  return out
+}
+
+let lastServer: ScoreMap = {}
+
+async function pollScores() {
+  if (!hasValidGameId.value) return
+  const data = await fetchScores(gameId.value)
+  const server = scoresToMap(data)
+  scores.value = mergeServerScores(scores.value, server, lastServer, lockedScores.value)
+  lastServer = server
+  const holeSet = new Set(holes.value)
+  for (const e of data) holeSet.add(e.hole)
+  if (holeSet.size !== holes.value.length) {
+    holes.value = [...holeSet].sort((a, b) => a - b)
+  }
+}
+
+useLivePolling(pollScores, 4000)
 
 /** Beschreibt den Chip-Zustand für Screenreader (nicht nur farblich). */
 function pillAriaLabel(holeNum: number) {
@@ -126,6 +157,8 @@ const nextNewHole = computed(() => {
 watchEffect(async () => {
   if (!hasValidGameId.value) return
   await loadGamesDetailData()
+  // Baseline für den Poll-Diff (Reads nach await erzeugen keine Watch-Deps).
+  lastServer = cloneScores(scores.value)
 })
 </script>
 

--- a/frontend/src/pages/games/GamesPage.vue
+++ b/frontend/src/pages/games/GamesPage.vue
@@ -15,14 +15,24 @@
               <h1 class="t-title games-detail__title" :title="gameName">
                 {{ displayName }}
               </h1>
-              <AppIconButton
-                :label="$t('Games.HoleView.EditGame')"
-                variant="outline"
-                size="md"
-                @click="$router.push(`/games/new/${gameId}`)"
-              >
-                <PencilSquareIcon class="w-5 h-5" />
-              </AppIconButton>
+              <div class="games-detail__title-actions">
+                <AppIconButton
+                  :label="$t('Share.Title')"
+                  variant="outline"
+                  size="md"
+                  @click="shareOpen = true"
+                >
+                  <ShareIcon class="w-5 h-5" />
+                </AppIconButton>
+                <AppIconButton
+                  :label="$t('Games.HoleView.EditGame')"
+                  variant="outline"
+                  size="md"
+                  @click="$router.push(`/games/new/${gameId}`)"
+                >
+                  <PencilSquareIcon class="w-5 h-5" />
+                </AppIconButton>
+              </div>
             </div>
 
             <!-- Direkter Loch-Zugriff: Chip-Leiste zum Springen in die Hole-View. -->
@@ -53,6 +63,8 @@
 
           <ScoreCard />
         </template>
+
+        <ShareGameSheet v-model="shareOpen" :game-id="gameId" :game-name="gameName" />
       </div>
     </template>
   </DefaultLayout>
@@ -63,11 +75,12 @@ import DefaultLayout from '@/layouts/DefaultLayout.vue'
 import GamesListCompact from '@/components/games/GamesListCompact.vue'
 import ScoreCard from '@/components/games/ScoreCard.vue'
 import GamesHoleView from '@/components/games/GamesHoleView.vue'
+import ShareGameSheet from '@/components/games/ShareGameSheet.vue'
 import ErrorState from '@/components/ui/ErrorState.vue'
 import AppIconButton from '@/components/ui/AppIconButton.vue'
 
-import { PencilSquareIcon, PlusIcon, CheckIcon } from '@heroicons/vue/24/outline'
-import { computed, provide, watchEffect } from 'vue'
+import { PencilSquareIcon, PlusIcon, CheckIcon, ShareIcon } from '@heroicons/vue/24/outline'
+import { computed, provide, ref, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 
@@ -79,6 +92,7 @@ import { VALIDATION } from '@/constants'
 
 const route = useRoute()
 const { t } = useI18n()
+const shareOpen = ref(false)
 const gameId = computed(() => route.params.gameId as string)
 const hasValidGameId = computed(() =>
   typeof gameId.value === 'string' && /^[a-zA-Z0-9_-]{10,30}$/.test(gameId.value)
@@ -140,6 +154,13 @@ watchEffect(async () => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.games-detail__title-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
 }
 
 /* Hole-Pill-Leiste: direkter Zugriff auf Löcher von allen drei Scorecard-Views */

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,6 +10,11 @@ export interface GamesDetailContext {
   gameName: Ref<string>
   error: Ref<string | null>
   load: () => Promise<void>
+  /**
+   * Aktiv editierte / gerade gespeicherte Score-Felder ("playerId:hole").
+   * Die Live-Aktualisierung überschreibt diese Felder nicht.
+   */
+  lockedScores: Ref<Set<string>>
 }
 
 export const gamesDetailKey: InjectionKey<GamesDetailContext> = Symbol('gamesDetailData')

--- a/frontend/src/utils/gameRef.test.ts
+++ b/frontend/src/utils/gameRef.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { parseGameRef } from './gameRef'
+
+describe('parseGameRef', () => {
+  const id = 'mock-game-alpha-2026'
+
+  it('accepts a bare valid id', () => {
+    expect(parseGameRef(id)).toBe(id)
+    expect(parseGameRef(`  ${id}  `)).toBe(id)
+  })
+
+  it('extracts the id from a full share link', () => {
+    expect(parseGameRef(`https://sc.urban-golf.ch/games/${id}`)).toBe(id)
+  })
+
+  it('extracts the game id even from a hole deep-link', () => {
+    expect(parseGameRef(`https://sc.urban-golf.ch/games/${id}/3`)).toBe(id)
+  })
+
+  it('rejects too-short or invalid ids', () => {
+    expect(parseGameRef('short')).toBeNull()
+    expect(parseGameRef('has spaces here')).toBeNull()
+    expect(parseGameRef('')).toBeNull()
+    expect(parseGameRef('https://example.com/other/path')).toBeNull()
+  })
+})

--- a/frontend/src/utils/gameRef.ts
+++ b/frontend/src/utils/gameRef.ts
@@ -1,0 +1,21 @@
+import { ID_PATTERN } from '@/constants'
+
+/**
+ * Extrahiert eine gültige Spiel-ID aus einem geteilten Link oder einer roh
+ * eingegebenen/gescannten ID. Akzeptiert sowohl `…/games/<id>` als auch
+ * `…/games/<id>/<hole>` sowie die bare ID. Gibt null zurück, wenn nichts
+ * Gültiges erkennbar ist.
+ */
+export function parseGameRef(input: string): string | null {
+  const value = input.trim()
+  if (!value) return null
+
+  // Bare ID
+  if (ID_PATTERN.test(value)) return value
+
+  // Aus einem Link: erstes /games/<id>-Segment
+  const match = value.match(/\/games\/([a-zA-Z0-9_-]+)/)
+  if (match && ID_PATTERN.test(match[1])) return match[1]
+
+  return null
+}

--- a/frontend/src/utils/mergeScores.test.ts
+++ b/frontend/src/utils/mergeScores.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { mergeServerScores, scoresToMap, scoreKey } from './mergeScores'
+import type { ScoreMap } from '@/types'
+
+const NONE = new Set<string>()
+
+describe('scoresToMap', () => {
+  it('groups flat score rows by player and hole', () => {
+    const map = scoresToMap([
+      { player_id: 'p1', hole: 1, strokes: 3 },
+      { player_id: 'p1', hole: 2, strokes: 4 },
+      { player_id: 'p2', hole: 1, strokes: 5 },
+    ])
+    expect(map).toEqual({ p1: { 1: 3, 2: 4 }, p2: { 1: 5 } })
+  })
+})
+
+describe('mergeServerScores', () => {
+  it('applies a value another device changed on the server', () => {
+    const local: ScoreMap = { p1: { 1: 3 } }
+    const last: ScoreMap = { p1: { 1: 3 } }
+    const server: ScoreMap = { p1: { 1: 5 } } // remote changed 3 → 5
+    const merged = mergeServerScores(local, server, last, NONE)
+    expect(merged.p1[1]).toBe(5)
+  })
+
+  it('preserves a local edit when the server field did not change', () => {
+    // User changed p1/1 locally to 9; server still shows the old 3 (save in flight)
+    const local: ScoreMap = { p1: { 1: 9 } }
+    const last: ScoreMap = { p1: { 1: 3 } }
+    const server: ScoreMap = { p1: { 1: 3 } }
+    const merged = mergeServerScores(local, server, last, NONE)
+    expect(merged.p1[1]).toBe(9)
+  })
+
+  it('never overwrites a locked (actively edited) field', () => {
+    const local: ScoreMap = { p1: { 1: 9 } }
+    const last: ScoreMap = { p1: { 1: 3 } }
+    const server: ScoreMap = { p1: { 1: 7 } } // remote changed, but field is locked
+    const merged = mergeServerScores(local, server, last, new Set([scoreKey('p1', 1)]))
+    expect(merged.p1[1]).toBe(9)
+  })
+
+  it('adds a brand new remote field', () => {
+    const local: ScoreMap = { p1: { 1: 3 } }
+    const last: ScoreMap = {}
+    const server: ScoreMap = { p1: { 1: 3 }, p2: { 1: 4 } }
+    const merged = mergeServerScores(local, server, last, NONE)
+    expect(merged.p2[1]).toBe(4)
+  })
+
+  it('does not mutate the original local map (new reference for touched player)', () => {
+    const local: ScoreMap = { p1: { 1: 3 } }
+    const last: ScoreMap = { p1: { 1: 3 } }
+    const server: ScoreMap = { p1: { 1: 5 } }
+    const merged = mergeServerScores(local, server, last, NONE)
+    expect(local.p1[1]).toBe(3) // original untouched
+    expect(merged).not.toBe(local)
+    expect(merged.p1).not.toBe(local.p1)
+  })
+})

--- a/frontend/src/utils/mergeScores.ts
+++ b/frontend/src/utils/mergeScores.ts
@@ -1,0 +1,54 @@
+import type { ScoreMap } from '@/types'
+
+/** Schlüssel eines Score-Feldes für das Locked-Set. */
+export function scoreKey(playerId: string, hole: number): string {
+  return `${playerId}:${hole}`
+}
+
+/**
+ * Merged frische Server-Scores in die lokale ScoreMap für die Live-Aktualisierung.
+ *
+ * Regeln:
+ * - Ein Server-Wert wird nur übernommen, wenn er sich seit dem letzten Poll
+ *   geändert hat (ein anderes Gerät hat geschrieben). Dadurch bleiben lokale
+ *   Edits an server-unveränderten Feldern erhalten.
+ * - Felder in `locked` (gerade aktiv editiert / im Save) werden nie überschrieben.
+ *
+ * Gibt eine neue ScoreMap zurück (nur berührte Spieler werden flach kopiert),
+ * damit Vue-Reaktivität sauber greift.
+ */
+export function mergeServerScores(
+  local: ScoreMap,
+  server: ScoreMap,
+  lastServer: ScoreMap,
+  locked: Set<string>,
+): ScoreMap {
+  const next: ScoreMap = { ...local }
+
+  for (const playerId in server) {
+    for (const holeStr in server[playerId]) {
+      const hole = Number(holeStr)
+      const serverVal = server[playerId][hole]
+      const lastVal = lastServer[playerId]?.[hole]
+
+      if (serverVal === lastVal) continue // keine Server-Änderung → lokal lassen
+      if (locked.has(scoreKey(playerId, hole))) continue // aktiv editiert
+
+      next[playerId] = { ...(next[playerId] ?? {}) }
+      next[playerId][hole] = serverVal
+    }
+  }
+
+  return next
+}
+
+/** Baut aus der rohen Scores-Liste eine ScoreMap. */
+export function scoresToMap(
+  entries: Array<{ player_id: string; hole: number; strokes: number }>,
+): ScoreMap {
+  const map: ScoreMap = {}
+  for (const e of entries) {
+    ;(map[e.player_id] ??= {})[e.hole] = e.strokes
+  }
+  return map
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "marked": "^18.0.2",
         "nanoid": "^5.1.6",
         "pinia": "^3.0.4",
+        "qrcode": "^1.5.4",
         "vue": "^3.4.15",
         "vue-i18n": "^11.1.6",
         "vue-router": "^5.0.0"
@@ -58,6 +59,7 @@
         "@playwright/test": "^1.61.1",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.0.0",
+        "@types/qrcode": "^1.5.6",
         "@vitejs/plugin-vue": "^6.0.0",
         "eslint": "^10.0.0",
         "eslint-plugin-vue": "^10.0.0",
@@ -3475,6 +3477,16 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -4721,6 +4733,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
@@ -5027,6 +5048,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5107,6 +5137,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -8153,6 +8189,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -8184,7 +8229,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8490,6 +8534,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8719,6 +8772,174 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -8913,6 +9134,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -9194,6 +9421,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
@@ -10837,6 +11070,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@urban-golf/contract": "*",
         "@vueuse/core": "^14.0.0",
         "axios": "^1.15.2",
+        "jsqr": "^1.4.0",
         "marked": "^18.0.2",
         "nanoid": "^5.1.6",
         "pinia": "^3.0.4",
@@ -7362,6 +7363,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/keyv": {
       "version": "4.5.4",


### PR DESCRIPTION
Setzt **PRD #82** vollständig um — Teilen per Link/QR, In-App-Scanner und Live-Aktualisierung — in eigenen Commits pro Slice.

## #94 — Teilen per Link
- Teilen-Button im **Detail-Header und in der Hole-View** (Teilen ist beim echten Spielen am nützlichsten).
- Sheet mit direktem Spiel-Link, **Web Share API** + **Copy-Fallback** (Desktop) mit „Kopiert!"-Bestätigung, transparenter Hinweis „jeder mit dem Link kann mitschreiben".
- Beitritt automatisch: Spiele-Liste ist server-global, `/games/:id` deep-linkt direkt.

## #95 — QR-Code + In-App-Scanner
- **QR-Code** zum Share-Link im Teilen-Sheet (clientseitig als `data:`-URL, CSP-konform).
- **In-App-Kamera-Scanner** („Spiel beitreten" auf der Liste): scannt den QR und tritt sofort bei; Kamera läuft nur während des Scans; **manueller Fallback** (Link/ID einfügen) + klare Meldungen bei verweigerter/fehlender Kamera. `parseGameRef` (Link/Deep-Link/bare ID) unit-getestet.
- nginx `Permissions-Policy` auf `camera=(self)` gelockert.

## #96 — Live-Aktualisierung per Polling
- Offenes Spiel pollt die Scores und **merged Remote-Änderungen** (Diff seit letztem Poll → lokale Edits bleiben erhalten; aktiv gespeicherte Felder via Lock geschützt).
- Polling **pausiert** bei verstecktem Tab und **verschluckt Fehler** still.
- **Read-only-Zuschauer-Modus** (`?spectator`): blendet alle Schreib-Einstiege aus, Rangliste aktualisiert live.

## Tests
`npm run test:all` grün: Lint · Type-Check · **~130 Unit-Tests** (useShareGame, useQrCode, parseGameRef, mergeServerScores u. a.) · **52 Smoke-Tests** (Teilen, QR, Beitreten-Fallback, Live-Update über echten Poll-Zyklus, Zuschauer-Modus). Neue Strings (`Share.*`, `Join.*`) in de/en/fr/nl — Paritäts- & Platzhalter-Gate grün.

## Neue Dependencies
`qrcode` (QR-Erzeugung), `jsqr` (QR-Decoding) — beide clientseitig, CSP-konform.

Closes #94
Closes #95
Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
