### PR TITLE
Identitäts-Redesign: created_by + kanonischer Spieler statt Namens-Claiming (#106)

### DIFF
--- a/backend/db/init/schema.sql
+++ b/backend/db/init/schema.sql
@@ -81,7 +81,8 @@ ALTER SEQUENCE public.game_players_id_seq OWNED BY public.game_players.id;
 CREATE TABLE public.games (
     id text NOT NULL,
     name text NOT NULL,
-    created_at timestamptz DEFAULT now()
+    created_at timestamptz DEFAULT now(),
+    created_by uuid
 );
 
 --
@@ -300,6 +301,15 @@ ALTER TABLE ONLY public.account_players
 
 ALTER TABLE ONLY public.account_players
     ADD CONSTRAINT fk_account_players_player FOREIGN KEY (player_id) REFERENCES public.players(id) ON DELETE CASCADE;
+
+--
+-- Spiel-Ownership: games.created_by → accounts (nach accounts definiert)
+--
+
+ALTER TABLE ONLY public.games
+    ADD CONSTRAINT fk_games_created_by FOREIGN KEY (created_by) REFERENCES public.accounts(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_games_created_by ON public.games USING btree (created_by);
 
 --
 -- PostgreSQL database dump complete

--- a/backend/db/init/schema.sql
+++ b/backend/db/init/schema.sql
@@ -255,8 +255,11 @@ CREATE TABLE public.accounts (
     email text NOT NULL UNIQUE,
     display_name text,
     avatar text,
+    player_id text REFERENCES public.players(id) ON DELETE SET NULL,
     created_at timestamptz DEFAULT now()
 );
+
+CREATE INDEX idx_accounts_player ON public.accounts USING btree (player_id);
 
 CREATE TABLE public.otp_codes (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/backend/db/migrations/007_game-created-by.sql
+++ b/backend/db/migrations/007_game-created-by.sql
@@ -1,0 +1,7 @@
+-- Spiel-Ownership: wer ein Spiel eingeloggt erstellt, wird als Ersteller vermerkt.
+-- Nullable — anonym erstellte Spiele haben keinen Ersteller. ON DELETE SET NULL,
+-- damit das Löschen eines Kontos die Spiele (und deren Scores) intakt lässt.
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS created_by uuid REFERENCES public.accounts(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_games_created_by ON public.games USING btree (created_by);

--- a/backend/db/migrations/008_account-canonical-player.sql
+++ b/backend/db/migrations/008_account-canonical-player.sql
@@ -1,0 +1,7 @@
+-- Kanonische Selbst-Identität: eine stabile Spieler-Zeile pro Konto.
+-- Ersetzt das namensbasierte Claiming — die Zuordnung läuft ab jetzt
+-- ausschließlich explizit über diese eine ID (kollisionsfrei).
+ALTER TABLE public.accounts
+  ADD COLUMN IF NOT EXISTS player_id text REFERENCES public.players(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_accounts_player ON public.accounts USING btree (player_id);

--- a/backend/db/migrations/009_reset-name-based-claims.sql
+++ b/backend/db/migrations/009_reset-name-based-claims.sql
@@ -1,0 +1,18 @@
+-- Cutover auf das kanonische Identitätsmodell (#106).
+--
+-- Bis hierher wurden Spieler-Einträge namensbasiert einem Konto zugeordnet
+-- (POST /auth/profile: alle players mit gleichem Namen). Das ist fragil
+-- (Namenskollisionen → vermischte Statistik) und wird durch die kanonische
+-- Selbst-Identität (accounts.player_id, Migration 008) ersetzt.
+--
+-- Dieser Cutover leert die alten Zuordnungen bewusst in Dev UND Prod
+-- (nur wenige Power-User). Alte Runden werden NICHT rückwirkend zugeordnet;
+-- Konten etablieren ihre Identität neu, sobald sie ihren Anzeigenamen setzen
+-- (legt den kanonischen Spieler an) und künftige Spiele mit der „Du"-Zeile
+-- bzw. als Ersteller (created_by) erfassen.
+--
+-- Idempotent: erneutes Ausführen leert eine bereits leere Tabelle folgenlos.
+DELETE FROM public.account_players;
+
+-- accounts.player_id ist für Bestandskonten bereits NULL (Spalte neu in 008),
+-- daher hier nichts weiter zurückzusetzen.

--- a/backend/routes/__tests__/auth.test.js
+++ b/backend/routes/__tests__/auth.test.js
@@ -214,8 +214,8 @@ describe('Auth routes', () => {
       expect(res.statusCode).toBe(401)
     })
 
-    it('returns the games of claimed players', async () => {
-      createMockClient([
+    it('returns owned and participated games (created_by ∪ claimed players)', async () => {
+      const client = createMockClient([
         ['FROM sessions s', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: 'Anna' }] }],
         ['WITH my_games AS', { rows: [{ id: 'g1', name: 'Stadtpark', players: [], holes: [1, 2] }] }],
       ])
@@ -227,6 +227,10 @@ describe('Auth routes', () => {
       expect(res.statusCode).toBe(200)
       expect(res.json().games).toHaveLength(1)
       expect(res.json().games[0].name).toBe('Stadtpark')
+
+      // Der Ownership-Zweig (created_by) muss Teil der Abfrage sein.
+      const myGamesCall = client.query.mock.calls.find((c) => c[0].includes('WITH my_games AS'))
+      expect(myGamesCall[0]).toContain('created_by = $1')
     })
   })
 

--- a/backend/routes/__tests__/auth.test.js
+++ b/backend/routes/__tests__/auth.test.js
@@ -82,6 +82,8 @@ describe('Auth routes', () => {
         ['SET consumed_at', { rows: [] }],
         ['INSERT INTO accounts', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: null }] }],
         ['INSERT INTO sessions', { rows: [] }],
+        // ensureCanonicalPlayer legt beim Login die kanonische Identität an.
+        ['UPDATE accounts SET display_name', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: 'a', avatar: null, player_id: 'canon-new-1' }] }],
       ])
       const res = await app.inject({
         method: 'POST',
@@ -89,7 +91,8 @@ describe('Auth routes', () => {
         payload: { email: 'a@b.com', code },
       })
       expect(res.statusCode).toBe(200)
-      expect(res.json().account).toMatchObject({ id: 'acc1', email: 'a@b.com', displayName: null })
+      // Kanonische Identität wird beim Login etabliert (Default-Name aus E-Mail).
+      expect(res.json().account).toMatchObject({ id: 'acc1', email: 'a@b.com', displayName: 'a', playerId: 'canon-new-1' })
       expect(res.cookies.find((c) => c.name === SESSION_COOKIE)).toBeTruthy()
     })
 
@@ -126,9 +129,10 @@ describe('Auth routes', () => {
       expect(res.statusCode).toBe(401)
     })
 
-    it('returns the account for a valid session', async () => {
-      createMockClient([
-        ['FROM sessions s', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: 'Anna' }] }],
+    it('backfills the canonical identity for a session that has none', async () => {
+      const client = createMockClient([
+        ['FROM sessions s', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: 'Anna', player_id: null }] }],
+        ['UPDATE accounts SET display_name', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: 'Anna', avatar: null, player_id: 'canon-me-1' }] }],
       ])
       const res = await app.inject({
         method: 'GET',
@@ -136,7 +140,24 @@ describe('Auth routes', () => {
         cookies: { [SESSION_COOKIE]: 'sometoken' },
       })
       expect(res.statusCode).toBe(200)
-      expect(res.json().account).toMatchObject({ id: 'acc1', email: 'a@b.com', displayName: 'Anna' })
+      expect(res.json().account).toMatchObject({ id: 'acc1', email: 'a@b.com', displayName: 'Anna', playerId: 'canon-me-1' })
+      expect(client.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO players'), expect.any(Array))
+    })
+
+    it('returns the account as-is when it already has a canonical identity', async () => {
+      const client = createMockClient([
+        ['FROM sessions s', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: 'Anna', player_id: 'canon-me-1' }] }],
+      ])
+      const res = await app.inject({
+        method: 'GET',
+        url: '/me',
+        cookies: { [SESSION_COOKIE]: 'sometoken' },
+      })
+      expect(res.statusCode).toBe(200)
+      expect(res.json().account).toMatchObject({ id: 'acc1', playerId: 'canon-me-1' })
+      // Kein Backfill nötig.
+      const insertPlayer = client.query.mock.calls.find((c) => c[0].includes('INSERT INTO players'))
+      expect(insertPlayer).toBeUndefined()
     })
   })
 

--- a/backend/routes/__tests__/auth.test.js
+++ b/backend/routes/__tests__/auth.test.js
@@ -147,11 +147,10 @@ describe('Auth routes', () => {
       expect(res.statusCode).toBe(401)
     })
 
-    it('sets the display name and claims players with that name', async () => {
+    it('sets the display name and creates the canonical self player (no name claiming)', async () => {
       const client = createMockClient([
-        ['FROM sessions s', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: null }] }],
-        ['UPDATE accounts SET display_name', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: 'Anna' }] }],
-        ['INSERT INTO account_players', { rows: [{ player_id: 'p1' }, { player_id: 'p2' }] }],
+        ['FROM sessions s', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: null, player_id: null }] }],
+        ['UPDATE accounts SET display_name', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: 'Anna', avatar: null, player_id: 'canon-player-1' }] }],
       ])
       const res = await app.inject({
         method: 'POST',
@@ -160,11 +159,36 @@ describe('Auth routes', () => {
         cookies: { [SESSION_COOKIE]: 'tok' },
       })
       expect(res.statusCode).toBe(200)
+      // Kein claimedCount mehr, dafür die kanonische playerId.
       expect(res.json()).toEqual({
-        account: { id: 'acc1', email: 'a@b.com', displayName: 'Anna', avatar: null },
-        claimedCount: 2,
+        account: { id: 'acc1', email: 'a@b.com', displayName: 'Anna', avatar: null, playerId: 'canon-player-1' },
       })
-      expect(client.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO account_players'), ['acc1', 'Anna'])
+      // Neue kanonische Spieler-Zeile wird angelegt …
+      expect(client.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO players'), expect.any(Array))
+      // … und account_players auf genau diese Zeile gesetzt (alte weggeräumt).
+      expect(client.query).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM account_players'), ['acc1'])
+      // Kein namensbasiertes Claiming.
+      const nameClaim = client.query.mock.calls.find((c) => c[0].includes('WHERE p.name = $2'))
+      expect(nameClaim).toBeUndefined()
+    })
+
+    it('renames the existing canonical player instead of creating a new one', async () => {
+      const client = createMockClient([
+        ['FROM sessions s', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: 'Anna', player_id: 'canon-player-1' }] }],
+        ['UPDATE accounts SET display_name', { rows: [{ id: 'acc1', email: 'a@b.com', display_name: 'Anna B.', avatar: null, player_id: 'canon-player-1' }] }],
+      ])
+      const res = await app.inject({
+        method: 'POST',
+        url: '/profile',
+        payload: { displayName: 'Anna B.' },
+        cookies: { [SESSION_COOKIE]: 'tok' },
+      })
+      expect(res.statusCode).toBe(200)
+      expect(res.json().account.playerId).toBe('canon-player-1')
+      // Umbenennen der bestehenden Zeile, kein neuer INSERT INTO players.
+      expect(client.query).toHaveBeenCalledWith(expect.stringContaining('UPDATE players SET name'), ['canon-player-1', 'Anna B.'])
+      const insertPlayer = client.query.mock.calls.find((c) => c[0].includes('INSERT INTO players'))
+      expect(insertPlayer).toBeUndefined()
     })
   })
 

--- a/backend/routes/__tests__/games.test.js
+++ b/backend/routes/__tests__/games.test.js
@@ -254,11 +254,11 @@ describe('GET /games/:id/players', () => {
 
   afterEach(() => app.close())
 
-  it('returns players for a game', async () => {
-    createMockClient(() => ({
+  it('returns players for a game, flagging registered identities', async () => {
+    const client = createMockClient(() => ({
       rows: [
-        { id: 'p1234567890123', name: 'Alice' },
-        { id: 'p2345678901234', name: 'Bob' },
+        { id: 'canon-alice-01', name: 'Alice', registered: true, avatar: null },
+        { id: 'p2345678901234', name: 'Bob', registered: false, avatar: null },
       ],
     }))
 
@@ -269,6 +269,10 @@ describe('GET /games/:id/players', () => {
 
     expect(res.statusCode).toBe(200)
     expect(res.json()).toHaveLength(2)
+    expect(res.json()[0].registered).toBe(true)
+    // Die Query markiert kanonische (Konto-)Identitäten.
+    const call = client.query.mock.calls.find((c) => c[0].includes('AS registered'))
+    expect(call).toBeDefined()
   })
 
   it('returns 400 for invalid game id', async () => {

--- a/backend/routes/__tests__/games.test.js
+++ b/backend/routes/__tests__/games.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import Fastify from 'fastify'
+import fastifyCookie from '@fastify/cookie'
 
 import { pgMock } from './_pgMock.js'
 
@@ -21,8 +22,16 @@ function createMockClient(queryImpl) {
 function buildApp() {
   const app = Fastify({ logger: false })
   app.setErrorHandler(handleError)
+  // Cookie-Plugin: nötig, damit POST /games die (optionale) Session lesen kann.
+  app.register(fastifyCookie)
   app.register(gameRoutes, { prefix: '/' })
   return app
+}
+
+// Findet die Parameter des INSERT-INTO-games-Aufrufs auf dem Mock-Client.
+function gamesInsertParams(client) {
+  const call = client.query.mock.calls.find((c) => c[0].includes('INSERT INTO games'))
+  return call?.[1]
 }
 
 describe('POST /games', () => {
@@ -60,6 +69,59 @@ describe('POST /games', () => {
     expect(client.query).toHaveBeenCalledWith('BEGIN')
     expect(client.query).toHaveBeenCalledWith('COMMIT')
     expect(client.release).toHaveBeenCalled()
+  })
+
+  it('stamps created_by from the session when logged in', async () => {
+    const client = createMockClient((sql) => {
+      // Session-Lookup in getAccountFromRequest
+      if (sql.includes('FROM sessions')) {
+        return { rows: [{ id: 'acc-owner-1', email: 'owner@example.com', display_name: null, avatar: null }] }
+      }
+      if (sql.includes('INSERT INTO games')) {
+        return { rows: [{ id: 'game1234567890', name: 'Owned Game' }] }
+      }
+      return { rows: [] }
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/',
+      cookies: { ug_session: 'valid-token' },
+      payload: {
+        id: 'game1234567890',
+        name: 'Owned Game',
+        players: ['player1234567890'],
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    // created_by ist der dritte Parameter des INSERT.
+    expect(gamesInsertParams(client)?.[2]).toBe('acc-owner-1')
+  })
+
+  it('leaves created_by null for anonymous creation', async () => {
+    const client = createMockClient((sql) => {
+      if (sql.includes('INSERT INTO games')) {
+        return { rows: [{ id: 'game1234567890', name: 'Anon Game' }] }
+      }
+      return { rows: [] }
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/',
+      payload: {
+        id: 'game1234567890',
+        name: 'Anon Game',
+        players: ['player1234567890'],
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(gamesInsertParams(client)?.[2]).toBeNull()
+    // Ohne Cookie darf kein Session-Lookup passieren.
+    const sessionCall = client.query.mock.calls.find((c) => c[0].includes('FROM sessions'))
+    expect(sessionCall).toBeUndefined()
   })
 
   it('returns 400 for invalid body', async () => {

--- a/backend/routes/__tests__/players.test.js
+++ b/backend/routes/__tests__/players.test.js
@@ -103,3 +103,38 @@ describe('GET /players', () => {
     expect(res.json()[0].name).toBe('Alice')
   })
 })
+
+describe('GET /players/search', () => {
+  let app
+
+  beforeEach(() => {
+    app = buildApp()
+    getClient.mockReset()
+  })
+
+  afterEach(() => app.close())
+
+  it('returns matching registered players', async () => {
+    const client = createMockClient(() => ({
+      rows: [{ id: 'canon-anna-01', name: 'Anna Meier', avatar: null }],
+    }))
+
+    const res = await app.inject({ method: 'GET', url: '/search?q=Anna' })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().players).toHaveLength(1)
+    expect(res.json().players[0].name).toBe('Anna Meier')
+    // Nur registrierte (Konto-)Identitäten: die Query joint accounts.
+    const call = client.query.mock.calls.find((c) => c[0].includes('JOIN players p ON p.id = a.player_id'))
+    expect(call).toBeDefined()
+    expect(call[1]).toEqual(['%Anna%'])
+  })
+
+  it('returns empty for a too-short query without hitting the db', async () => {
+    const client = createMockClient(() => ({ rows: [] }))
+    const res = await app.inject({ method: 'GET', url: '/search?q=A' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().players).toEqual([])
+    expect(client.query).not.toHaveBeenCalled()
+  })
+})

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -9,6 +9,7 @@ import {
   hashToken,
   generateOtpCode,
   generateSessionToken,
+  generatePlayerId,
   normalizeEmail,
   sessionCookieOptions,
   getAccountFromRequest,
@@ -20,6 +21,7 @@ const toAccount = (r) => ({
   email: r.email,
   displayName: r.display_name,
   avatar: r.avatar ?? null,
+  playerId: r.player_id ?? null,
 });
 
 export default async function (fastify, _opts) {
@@ -98,7 +100,7 @@ export default async function (fastify, _opts) {
       account = await queryOne(
         `INSERT INTO accounts (email) VALUES ($1)
            ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email
-         RETURNING id, email, display_name, avatar`,
+         RETURNING id, email, display_name, avatar, player_id`,
         [email],
       );
 
@@ -128,28 +130,46 @@ export default async function (fastify, _opts) {
     }
   });
 
-  // Anzeigename setzen + eigene Spieler-Einträge (per Name) beanspruchen.
+  // Anzeigename setzen. Etabliert die kanonische Selbst-Identität: eine
+  // stabile Spieler-Zeile pro Konto. KEIN namensbasiertes Claiming mehr —
+  // die Zuordnung läuft ausschließlich explizit über diese eine ID.
   fastify.post('/profile', {
     schema: schemas.postAuthProfile,
     preHandler: requireAuth,
     config: { rateLimit: { max: 20, timeWindow: '1 minute' } },
   }, async (request, reply) => {
     const displayName = request.body.displayName.trim();
+    const accountId = request.account.id;
     try {
-      const account = await queryOne(
-        `UPDATE accounts SET display_name = $2 WHERE id = $1
-         RETURNING id, email, display_name, avatar`,
-        [request.account.id, displayName],
-      );
-      // Anonyme Spieler-Einträge mit exakt diesem Namen dem Account zuordnen.
-      const claimed = await query(
-        `INSERT INTO account_players (account_id, player_id)
-         SELECT $1, p.id FROM players p WHERE p.name = $2
-         ON CONFLICT DO NOTHING
-         RETURNING player_id`,
-        [request.account.id, displayName],
-      );
-      return reply.send({ account: toAccount(account), claimedCount: claimed.length });
+      const account = await transaction(async (client) => {
+        // Kanonische Spieler-Zeile anlegen (falls noch keine) oder umbenennen.
+        let playerId = request.account.playerId;
+        if (playerId) {
+          await client.query(`UPDATE players SET name = $2 WHERE id = $1`, [playerId, displayName]);
+        } else {
+          playerId = generatePlayerId();
+          await client.query(`INSERT INTO players (id, name) VALUES ($1, $2)`, [playerId, displayName]);
+        }
+
+        const updated = await client.query(
+          `UPDATE accounts SET display_name = $2, player_id = $3 WHERE id = $1
+           RETURNING id, email, display_name, avatar, player_id`,
+          [accountId, displayName, playerId],
+        );
+
+        // account_players auf genau die kanonische Selbst-Zeile setzen —
+        // räumt zugleich etwaige alte (namensbasierte) Zuordnungen weg.
+        await client.query(`DELETE FROM account_players WHERE account_id = $1`, [accountId]);
+        await client.query(
+          `INSERT INTO account_players (account_id, player_id) VALUES ($1, $2)
+           ON CONFLICT DO NOTHING`,
+          [accountId, playerId],
+        );
+
+        return updated.rows[0];
+      });
+
+      return reply.send({ account: toAccount(account) });
     } catch (err) {
       request.log.error(err);
       return reply.code(500).send({ error: 'Database error' });
@@ -168,7 +188,7 @@ export default async function (fastify, _opts) {
     try {
       const account = await queryOne(
         `UPDATE accounts SET avatar = $2 WHERE id = $1
-         RETURNING id, email, display_name, avatar`,
+         RETURNING id, email, display_name, avatar, player_id`,
         [request.account.id, value],
       );
       return reply.send({ account: toAccount(account) });

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -24,6 +24,44 @@ const toAccount = (r) => ({
   playerId: r.player_id ?? null,
 });
 
+// Default-Anzeigename aus der E-Mail (lokaler Teil), falls der Nutzer noch
+// keinen gesetzt hat — damit er trotzdem eine benannte Identität bekommt.
+const defaultNameFromEmail = (email) =>
+  (String(email).split('@')[0] || 'Spieler').slice(0, 30);
+
+/**
+ * Stellt sicher, dass ein Konto eine kanonische Spieler-Identität besitzt.
+ * Wird beim Login und beim Laden der Session (/me) aufgerufen, damit ein
+ * eingeloggter Nutzer beim Erstellen eines Spiels automatisch als Spieler
+ * (die „Du"-Zeile) auftaucht — auch ohne zuvor einen Anzeigenamen zu setzen.
+ * Akzeptiert eine DB-Zeile (snake_case) und gibt eine solche zurück.
+ */
+async function ensureCanonicalPlayer(account) {
+  const existingId = account.player_id ?? account.playerId ?? null;
+  if (existingId) return account;
+
+  const displayName = account.display_name ?? account.displayName ?? null;
+  const name = (displayName && displayName.trim()) || defaultNameFromEmail(account.email);
+  const playerId = generatePlayerId();
+
+  return await transaction(async (client) => {
+    await client.query(
+      `INSERT INTO players (id, name) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`,
+      [playerId, name],
+    );
+    const updated = await client.query(
+      `UPDATE accounts SET display_name = COALESCE(display_name, $2), player_id = $3 WHERE id = $1
+       RETURNING id, email, display_name, avatar, player_id`,
+      [account.id, name, playerId],
+    );
+    await client.query(
+      `INSERT INTO account_players (account_id, player_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+      [account.id, playerId],
+    );
+    return updated.rows[0];
+  });
+}
+
 export default async function (fastify, _opts) {
   // Einmalcode anfordern. Antwortet immer 200 (kein Account-Enumeration-Leak).
   fastify.post('/request-otp', {
@@ -110,6 +148,10 @@ export default async function (fastify, _opts) {
         [account.id, hashToken(token), new Date(Date.now() + SESSION_TTL_MS)],
       );
       reply.setCookie(SESSION_COOKIE, token, sessionCookieOptions());
+
+      // Jedes eingeloggte Konto bekommt garantiert eine kanonische Identität,
+      // damit es beim Erstellen eines Spiels automatisch als Spieler auftaucht.
+      account = await ensureCanonicalPlayer(account);
     } catch (err) {
       request.log.error(err);
       return reply.code(500).send({ error: 'Database error' });
@@ -118,11 +160,17 @@ export default async function (fastify, _opts) {
     return reply.send({ account: toAccount(account) });
   });
 
-  // Aktuelle Session/Account.
+  // Aktuelle Session/Account. Backfillt bei Bedarf die kanonische Identität,
+  // damit auch bestehende Sessions (vor der Umstellung) sie beim App-Start
+  // erhalten.
   fastify.get('/me', async (request, reply) => {
     try {
       const account = await getAccountFromRequest(request);
       if (!account) return reply.code(401).send({ error: 'unauthenticated' });
+      if (!account.playerId) {
+        const updated = await ensureCanonicalPlayer(account);
+        return reply.send({ account: toAccount(updated) });
+      }
       return reply.send({ account });
     } catch (err) {
       request.log.error(err);

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -183,12 +183,18 @@ export default async function (fastify, _opts) {
     try {
       const games = await query(
         `WITH my_games AS (
-           SELECT DISTINCT g.id, g.name, g.created_at
+           -- Selbst erstellte Runden (Ownership) …
+           SELECT g.id, g.name, g.created_at
+           FROM games g
+           WHERE g.created_by = $1
+           UNION
+           -- … plus Runden, in denen ein mir zugeordneter Spieler mitspielt.
+           SELECT g.id, g.name, g.created_at
            FROM games g
            JOIN game_players gp ON gp.game_id = g.id
            JOIN account_players ap ON ap.player_id = gp.player_id
            WHERE ap.account_id = $1
-           ORDER BY g.created_at DESC
+           ORDER BY created_at DESC
            LIMIT 100
          ),
          player_stats AS (

--- a/backend/routes/games.js
+++ b/backend/routes/games.js
@@ -1,5 +1,6 @@
 import { query, queryOne, transaction } from '../db/pg.js';
 import { schemas, isValidId } from '@urban-golf/contract';
+import { getAccountFromRequest } from '../utils/auth.js';
 
 export default async function (fastify, _opts) {
   // Spiel erstellen oder aktualisieren
@@ -16,13 +17,21 @@ export default async function (fastify, _opts) {
     const validPlayers = players.filter(pid => isValidId(pid));
 
     try {
+      // Optionale Identität: ist der Request eingeloggt, wird der Ersteller
+      // serverseitig aus der Session abgeleitet (nie aus Client-Feldern).
+      // Anonym bleibt created_by NULL — der Flow bleibt unverändert.
+      const account = await getAccountFromRequest(req);
+      const createdBy = account?.id ?? null;
+
       const game = await transaction(async (client) => {
         const gameResult = await client.query(
-          `INSERT INTO games (id, name)
-           VALUES ($1, $2)
+          // created_by wird nur beim Anlegen gesetzt; beim Bearbeiten (ON CONFLICT)
+          // bleibt der ursprüngliche Ersteller unangetastet.
+          `INSERT INTO games (id, name, created_by)
+           VALUES ($1, $2, $3)
            ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name
            RETURNING id, name`,
-          [id, name]
+          [id, name, createdBy]
         );
 
         if (validPlayers.length > 0) {

--- a/backend/routes/games.js
+++ b/backend/routes/games.js
@@ -136,7 +136,11 @@ export default async function (fastify, _opts) {
     if (!isValidId(gameId)) return reply.code(400).send({ error: 'Invalid game ID' });
 
     const rows = await query(
-      `SELECT p.id, p.name
+      // registered/avatar: markiert kanonische (Konto-)Identitäten, damit die
+      // Bearbeiten-Ansicht sie read-only hält (kein versehentliches Umbenennen).
+      `SELECT p.id, p.name,
+              EXISTS (SELECT 1 FROM accounts a WHERE a.player_id = p.id) AS registered,
+              (SELECT a.avatar FROM accounts a WHERE a.player_id = p.id) AS avatar
        FROM players p
        JOIN game_players gp ON gp.player_id = p.id
        WHERE gp.game_id = $1`,

--- a/backend/routes/players.js
+++ b/backend/routes/players.js
@@ -33,4 +33,29 @@ export default async function (fastify, _opts) {
     const rows = await query('SELECT * FROM players ORDER BY name');
     reply.send(rows);
   });
+
+  // Registrierte Spieler suchen (Konten mit kanonischer Identität, d. h.
+  // gesetztem Anzeigenamen). Für die Spielersuche beim Erstellen eines
+  // Spiels — bewusst auch ohne Login nutzbar.
+  fastify.get('/search', {
+    config: { rateLimit: { max: 30, timeWindow: '1 minute' } },
+  }, async (req, reply) => {
+    const q = String(req.query.q || '').trim();
+    if (q.length < 2) return reply.send({ players: [] });
+    try {
+      const rows = await query(
+        `SELECT p.id, p.name, a.avatar
+         FROM accounts a
+         JOIN players p ON p.id = a.player_id
+         WHERE a.display_name IS NOT NULL AND p.name ILIKE $1
+         ORDER BY p.name
+         LIMIT 10`,
+        [`%${q}%`],
+      );
+      reply.send({ players: rows });
+    } catch (err) {
+      fastify.log.error(err);
+      reply.code(500).send({ error: 'Database error' });
+    }
+  });
 }

--- a/backend/utils/auth.js
+++ b/backend/utils/auth.js
@@ -24,6 +24,15 @@ export function generateSessionToken() {
   return crypto.randomBytes(32).toString('base64url');
 }
 
+/**
+ * Server-seitige Spieler-ID für die kanonische Selbst-Identität eines Kontos.
+ * 22 Zeichen base64url — passt in ID_PATTERN ([a-zA-Z0-9_-]{10,30}), damit sie
+ * clientseitig als Spieler-ID in POST /games mitgeschickt werden darf.
+ */
+export function generatePlayerId() {
+  return crypto.randomBytes(16).toString('base64url');
+}
+
 export function normalizeEmail(email) {
   return String(email).trim().toLowerCase();
 }
@@ -49,14 +58,14 @@ export async function getAccountFromRequest(request) {
   const token = request.cookies?.[SESSION_COOKIE];
   if (!token) return null;
   const row = await queryOne(
-    `SELECT a.id, a.email, a.display_name, a.avatar
+    `SELECT a.id, a.email, a.display_name, a.avatar, a.player_id
        FROM sessions s
        JOIN accounts a ON a.id = s.account_id
       WHERE s.token_hash = $1 AND s.expires_at > now()`,
     [hashToken(token)],
   );
   return row
-    ? { id: row.id, email: row.email, displayName: row.display_name, avatar: row.avatar ?? null }
+    ? { id: row.id, email: row.email, displayName: row.display_name, avatar: row.avatar ?? null, playerId: row.player_id ?? null }
     : null;
 }
 

--- a/frontend/e2e/smoke/game-ownership.spec.ts
+++ b/frontend/e2e/smoke/game-ownership.spec.ts
@@ -29,4 +29,30 @@ test.describe('Spiel-Ownership (Smoke)', () => {
     await page.getByRole('tab', { name: 'Meine' }).click()
     await expect(page.getByText('Ownership-Testrunde')).toBeVisible()
   })
+
+  test('eingeloggt mit Profil zeigt die „Du"-Zeile beim neuen Spiel', async ({ page, mockApi }) => {
+    void mockApi
+    await signIn(page)
+
+    // Anzeigename setzen → etabliert die kanonische Identität (playerId)
+    await page.getByRole('button', { name: /Profil öffnen|Open profile/i }).click()
+    await page.getByRole('button', { name: /Anzeigename/ }).click()
+    await page.locator('#settings-name').fill('Selbsttester')
+    await page.getByRole('button', { name: 'Absenden' }).click()
+    await expect(page.locator('.toast__message')).toBeVisible()
+    await page.keyboard.press('Escape')
+
+    // Neues Spiel: die „Du"-Zeile ist da, vorbefüllt und als „Du" markiert
+    await page.goto('/games/new')
+    const selfRow = page.locator('.new-game__player--self')
+    await expect(selfRow).toBeVisible()
+    await expect(selfRow.locator('.new-game__self-name')).toHaveText('Selbsttester')
+    await expect(selfRow.locator('.new-game__self-badge')).toHaveText('Du')
+  })
+
+  test('anonym gibt es keine „Du"-Zeile', async ({ page, mockApi }) => {
+    void mockApi
+    await page.goto('/games/new')
+    await expect(page.locator('.new-game__player--self')).toHaveCount(0)
+  })
 })

--- a/frontend/e2e/smoke/game-ownership.spec.ts
+++ b/frontend/e2e/smoke/game-ownership.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from './fixtures'
+
+async function signIn(page: import('@playwright/test').Page) {
+  await page.goto('/')
+  await page.getByRole('button', { name: /Profil öffnen|Open profile/i }).click()
+  await page.getByRole('button', { name: 'Anmelden', exact: true }).click()
+  const sheet = page.locator('.sheet').last()
+  await sheet.locator('#auth-email').fill('spieler@example.com')
+  await sheet.getByRole('button', { name: 'Code anfordern' }).click()
+  await sheet.locator('#auth-code').fill('123456')
+  await sheet.getByRole('button', { name: 'Anmelden', exact: true }).click()
+  await expect(page.locator('.sheet')).toHaveCount(0)
+}
+
+test.describe('Spiel-Ownership (Smoke)', () => {
+  test('eingeloggt erstelltes Spiel erscheint in „Meine Spiele"', async ({ page, mockApi }) => {
+    void mockApi
+    await signIn(page)
+
+    // Neues Spiel eingeloggt erstellen
+    await page.goto('/games/new')
+    await page.locator('input#game-name').fill('Ownership-Testrunde')
+    await page.locator('.new-game__player-input').first().fill('Testspieler Eins')
+    await page.getByRole('button', { name: 'Spiel starten' }).click()
+    await page.waitForURL(/\/games\/[^/]+\/1$/)
+
+    // In „Meine Spiele" muss die selbst erstellte Runde auftauchen (created_by)
+    await page.goto('/games')
+    await page.getByRole('tab', { name: 'Meine' }).click()
+    await expect(page.getByText('Ownership-Testrunde')).toBeVisible()
+  })
+})

--- a/frontend/e2e/smoke/game-ownership.spec.ts
+++ b/frontend/e2e/smoke/game-ownership.spec.ts
@@ -13,14 +13,27 @@ async function signIn(page: import('@playwright/test').Page) {
 }
 
 test.describe('Spiel-Ownership (Smoke)', () => {
+  test('eingeloggt ist man automatisch als Spieler 1 („Du") dabei', async ({ page, mockApi }) => {
+    void mockApi
+    await signIn(page)
+
+    // Ohne einen Anzeigenamen zu setzen: die „Du"-Zeile ist automatisch da,
+    // mit dem Default-Namen aus der E-Mail (lokaler Teil).
+    await page.goto('/games/new')
+    const selfRow = page.locator('.new-game__player--self')
+    await expect(selfRow).toBeVisible()
+    await expect(selfRow.locator('.new-game__self-badge')).toHaveText('Du')
+    await expect(selfRow.locator('.new-game__self-name')).toHaveText('spieler')
+  })
+
   test('eingeloggt erstelltes Spiel erscheint in „Meine Spiele"', async ({ page, mockApi }) => {
     void mockApi
     await signIn(page)
 
-    // Neues Spiel eingeloggt erstellen
+    // Neues Spiel eingeloggt erstellen — die „Du"-Zeile genügt als Spieler 1.
     await page.goto('/games/new')
     await page.locator('input#game-name').fill('Ownership-Testrunde')
-    await page.locator('.new-game__player-input').first().fill('Testspieler Eins')
+    await expect(page.locator('.new-game__player--self')).toBeVisible()
     await page.getByRole('button', { name: 'Spiel starten' }).click()
     await page.waitForURL(/\/games\/[^/]+\/1$/)
 
@@ -30,11 +43,10 @@ test.describe('Spiel-Ownership (Smoke)', () => {
     await expect(page.getByText('Ownership-Testrunde')).toBeVisible()
   })
 
-  test('eingeloggt mit Profil zeigt die „Du"-Zeile beim neuen Spiel', async ({ page, mockApi }) => {
+  test('der Anzeigename aus dem Profil erscheint in der „Du"-Zeile', async ({ page, mockApi }) => {
     void mockApi
     await signIn(page)
 
-    // Anzeigename setzen → etabliert die kanonische Identität (playerId)
     await page.getByRole('button', { name: /Profil öffnen|Open profile/i }).click()
     await page.getByRole('button', { name: /Anzeigename/ }).click()
     await page.locator('#settings-name').fill('Selbsttester')
@@ -42,12 +54,10 @@ test.describe('Spiel-Ownership (Smoke)', () => {
     await expect(page.locator('.toast__message')).toBeVisible()
     await page.keyboard.press('Escape')
 
-    // Neues Spiel: die „Du"-Zeile ist da, vorbefüllt und als „Du" markiert
     await page.goto('/games/new')
     const selfRow = page.locator('.new-game__player--self')
     await expect(selfRow).toBeVisible()
     await expect(selfRow.locator('.new-game__self-name')).toHaveText('Selbsttester')
-    await expect(selfRow.locator('.new-game__self-badge')).toHaveText('Du')
   })
 
   test('anonym gibt es keine „Du"-Zeile', async ({ page, mockApi }) => {

--- a/frontend/e2e/smoke/identity.spec.ts
+++ b/frontend/e2e/smoke/identity.spec.ts
@@ -13,15 +13,15 @@ async function signIn(page: import('@playwright/test').Page) {
 }
 
 test.describe('Identität ↔ Spieler & Meine Spiele (Smoke)', () => {
-  test('Anzeigename setzen ordnet Runden zu', async ({ page, mockApi }) => {
+  test('Anzeigename setzen bestätigt das Speichern', async ({ page, mockApi }) => {
     void mockApi
     await signIn(page)
     await page.getByRole('button', { name: /Profil öffnen|Open profile/i }).click()
     await page.getByRole('button', { name: /Anzeigename/ }).click()
     await page.locator('#settings-name').fill('Anna Meier')
     await page.getByRole('button', { name: 'Absenden' }).click()
-    // Toast bestätigt die Zuordnung
-    await expect(page.locator('.toast__message').filter({ hasText: /zugeordnet/ })).toBeVisible()
+    // Toast bestätigt das Speichern (kein namensbasiertes Claiming mehr)
+    await expect(page.locator('.toast__message').filter({ hasText: /gespeichert|saved/i })).toBeVisible()
   })
 
   test('„Meine Spiele"-Filter zeigt die eigenen Runden', async ({ page, mockApi }) => {

--- a/frontend/e2e/smoke/mock-api.ts
+++ b/frontend/e2e/smoke/mock-api.ts
@@ -198,7 +198,7 @@ export async function installMockApi(page: Page, seed?: MockDataset) {
   // ---- Auth (optionale Identität) ----
   // Zustandsbehaftet, damit die "Session" auch einen Reload (page.goto) überlebt
   // — wie ein echtes Cookie.
-  const authState: { account: { id: string; email: string; displayName: string | null; avatar: string | null } | null } = { account: null }
+  const authState: { account: { id: string; email: string; displayName: string | null; avatar: string | null; playerId: string | null } | null } = { account: null }
 
   await page.route('**/api/auth/request-otp', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) }),
@@ -206,7 +206,7 @@ export async function installMockApi(page: Page, seed?: MockDataset) {
   await page.route('**/api/auth/verify-otp', (route) => {
     const payload = JSON.parse(route.request().postData() || '{}') as { email: string; code: string }
     if (payload.code === '123456') {
-      authState.account = { id: 'acc-mock-1', email: payload.email, displayName: null, avatar: null }
+      authState.account = { id: 'acc-mock-1', email: payload.email, displayName: null, avatar: null, playerId: null }
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -227,11 +227,15 @@ export async function installMockApi(page: Page, seed?: MockDataset) {
   })
   await page.route('**/api/auth/profile', (route) => {
     const p = JSON.parse(route.request().postData() || '{}') as { displayName: string }
-    if (authState.account) authState.account.displayName = p.displayName
+    // Etabliert die kanonische Selbst-Identität (playerId) — kein Claiming.
+    if (authState.account) {
+      authState.account.displayName = p.displayName
+      authState.account.playerId = authState.account.playerId ?? 'canon-player-mock'
+    }
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ account: authState.account ?? { id: 'acc-mock-1', email: 'spieler@example.com', displayName: p.displayName, avatar: null }, claimedCount: 2 }),
+      body: JSON.stringify({ account: authState.account ?? { id: 'acc-mock-1', email: 'spieler@example.com', displayName: p.displayName, avatar: null, playerId: 'canon-player-mock' } }),
     })
   })
   await page.route('**/api/auth/avatar', (route) => {
@@ -241,7 +245,7 @@ export async function installMockApi(page: Page, seed?: MockDataset) {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ account: authState.account ?? { id: 'acc-mock-1', email: 'spieler@example.com', displayName: null, avatar: value } }),
+      body: JSON.stringify({ account: authState.account ?? { id: 'acc-mock-1', email: 'spieler@example.com', displayName: null, avatar: value, playerId: null } }),
     })
   })
   await page.route('**/api/auth/stats', (route) =>

--- a/frontend/e2e/smoke/mock-api.ts
+++ b/frontend/e2e/smoke/mock-api.ts
@@ -88,6 +88,10 @@ function buildSummary(data: MockDataset) {
 export async function installMockApi(page: Page, seed?: MockDataset) {
   const state: MockDataset = seed ? structuredClone(seed) : defaultDataset()
 
+  // Spiele, die während der Session eingeloggt erstellt wurden (created_by).
+  // Fließen zusätzlich in „Meine Spiele" ein — spiegelt das Ownership-Modell.
+  const createdByMe: Array<{ id: string; name: string; created_at: string; players: unknown[]; holes: number[] }> = []
+
   await page.route('**/api/games/summary**', (route) => {
     route.fulfill({
       status: 200,
@@ -108,6 +112,10 @@ export async function installMockApi(page: Page, seed?: MockDataset) {
       }
       state.games.push(game)
       state.gamePlayers[game.id] = payload.players
+      // Ist die Session eingeloggt, gilt der Ersteller (created_by) → „Meine Spiele".
+      if (authState.account) {
+        createdByMe.unshift({ id: game.id, name: game.name, created_at: game.created_at, players: [], holes: [] })
+      }
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -285,13 +293,17 @@ export async function installMockApi(page: Page, seed?: MockDataset) {
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        games: [{
-          id: 'mock-game-alpha-2026',
-          name: 'Stadtpark-Runde',
-          created_at: '2026-04-12T18:30:00Z',
-          players: [{ id: 'pl-anna-meier-001', name: 'Anna Meier', avg: 3.67, total: 11 }],
-          holes: [1, 2, 3],
-        }],
+        // Selbst erstellte Runden (Ownership) zuerst, dann die Fixture-Runde.
+        games: [
+          ...createdByMe,
+          {
+            id: 'mock-game-alpha-2026',
+            name: 'Stadtpark-Runde',
+            created_at: '2026-04-12T18:30:00Z',
+            players: [{ id: 'pl-anna-meier-001', name: 'Anna Meier', avg: 3.67, total: 11 }],
+            holes: [1, 2, 3],
+          },
+        ],
       }),
     }),
   )

--- a/frontend/e2e/smoke/mock-api.ts
+++ b/frontend/e2e/smoke/mock-api.ts
@@ -214,7 +214,15 @@ export async function installMockApi(page: Page, seed?: MockDataset) {
   await page.route('**/api/auth/verify-otp', (route) => {
     const payload = JSON.parse(route.request().postData() || '{}') as { email: string; code: string }
     if (payload.code === '123456') {
-      authState.account = { id: 'acc-mock-1', email: payload.email, displayName: null, avatar: null, playerId: null }
+      // Wie im Backend: der Login etabliert die kanonische Identität
+      // (Default-Anzeigename aus dem lokalen E-Mail-Teil).
+      authState.account = {
+        id: 'acc-mock-1',
+        email: payload.email,
+        displayName: payload.email.split('@')[0],
+        avatar: null,
+        playerId: 'canon-mock-self',
+      }
       return route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/frontend/e2e/smoke/mock-api.ts
+++ b/frontend/e2e/smoke/mock-api.ts
@@ -174,6 +174,14 @@ export async function installMockApi(page: Page, seed?: MockDataset) {
     })
   })
 
+  await page.route('**/api/players/search**', (route) => {
+    const url = new URL(route.request().url())
+    const q = (url.searchParams.get('q') || '').trim().toLowerCase()
+    const registered = [{ id: 'canon-registered-rita', name: 'Registrierte Rita', avatar: null }]
+    const players = q.length >= 2 ? registered.filter((p) => p.name.toLowerCase().includes(q)) : []
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ players }) })
+  })
+
   await page.route('**/api/scores**', async (route) => {
     const req = route.request()
     if (req.method() === 'POST') {

--- a/frontend/e2e/smoke/player-search.spec.ts
+++ b/frontend/e2e/smoke/player-search.spec.ts
@@ -1,21 +1,18 @@
 import { test, expect } from './fixtures'
 
 test.describe('Spielersuche (Smoke)', () => {
-  test('fügt einen registrierten Spieler zum neuen Spiel hinzu (auch ohne Login)', async ({ page, mockApi }) => {
+  test('Autocomplete verknüpft einen registrierten Spieler beim Tippen', async ({ page, mockApi }) => {
     void mockApi
     await page.goto('/games/new')
 
-    // Suche öffnen und nach einem registrierten Spieler suchen
-    await page.getByRole('button', { name: /Registrierten Spieler suchen|Find registered player/ }).click()
-    await page.locator('.new-game__search-input').fill('Rita')
+    // In eine Freitext-Spielerzeile einen Namen tippen → Vorschlag erscheint
+    await page.locator('.new-game__player-input').first().fill('Rita')
+    await page.locator('.new-game__suggest-item').first().click()
 
-    // Ergebnis auswählen → registrierte, read-only Zeile
-    await page.locator('.new-game__result').first().click()
-
+    // Die Zeile ist jetzt eine registrierte, read-only Identität
     const registered = page.locator('.new-game__self--registered')
     await expect(registered).toBeVisible()
     await expect(registered.locator('.new-game__self-name')).toHaveText('Registrierte Rita')
-    // Kein Freitext-Input für die registrierte Zeile
     await expect(registered.locator('input')).toHaveCount(0)
   })
 })

--- a/frontend/e2e/smoke/player-search.spec.ts
+++ b/frontend/e2e/smoke/player-search.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from './fixtures'
+
+test.describe('Spielersuche (Smoke)', () => {
+  test('fügt einen registrierten Spieler zum neuen Spiel hinzu (auch ohne Login)', async ({ page, mockApi }) => {
+    void mockApi
+    await page.goto('/games/new')
+
+    // Suche öffnen und nach einem registrierten Spieler suchen
+    await page.getByRole('button', { name: /Registrierten Spieler suchen|Find registered player/ }).click()
+    await page.locator('.new-game__search-input').fill('Rita')
+
+    // Ergebnis auswählen → registrierte, read-only Zeile
+    await page.locator('.new-game__result').first().click()
+
+    const registered = page.locator('.new-game__self--registered')
+    await expect(registered).toBeVisible()
+    await expect(registered.locator('.new-game__self-name')).toHaveText('Registrierte Rita')
+    // Kein Freitext-Input für die registrierte Zeile
+    await expect(registered.locator('input')).toHaveCount(0)
+  })
+})

--- a/frontend/src/components/about/Roadmap.vue
+++ b/frontend/src/components/about/Roadmap.vue
@@ -125,7 +125,7 @@ const features: Feature[] = [
   { key: 'OpenSource', icon: GlobeAltIcon, done: true, visible: true },
   { key: 'UserManagement', icon: UserIcon, done: true, visible: true },
   { key: 'CourseManagement', icon: ClipboardDocumentListIcon, done: false, visible: true },
-  { key: 'Stats', icon: ChartBarIcon, done: false, visible: true },
+  { key: 'Stats', icon: ChartBarIcon, done: true, visible: true },
   { key: 'DesignImprovements', icon: AdjustmentsHorizontalIcon, done: false, visible: true },
   { key: 'ClubManagement', icon: UsersIcon, done: false, visible: true },
   { key: 'Desktop', icon: ComputerDesktopIcon, done: false, visible: true },

--- a/frontend/src/components/about/Roadmap.vue
+++ b/frontend/src/components/about/Roadmap.vue
@@ -123,7 +123,7 @@ const features: Feature[] = [
   { key: 'Documentation', icon: BookOpenIcon, done: true, visible: true },
   { key: 'InitialRelease', icon: RocketLaunchIcon, done: true, visible: true },
   { key: 'OpenSource', icon: GlobeAltIcon, done: true, visible: true },
-  { key: 'UserManagement', icon: UserIcon, done: false, visible: true },
+  { key: 'UserManagement', icon: UserIcon, done: true, visible: true },
   { key: 'CourseManagement', icon: ClipboardDocumentListIcon, done: false, visible: true },
   { key: 'Stats', icon: ChartBarIcon, done: false, visible: true },
   { key: 'DesignImprovements', icon: AdjustmentsHorizontalIcon, done: false, visible: true },

--- a/frontend/src/components/games/GamesHoleView.vue
+++ b/frontend/src/components/games/GamesHoleView.vue
@@ -226,6 +226,18 @@ const { t } = useI18n()
 const gameId = computed(() => route.params.gameId as string)
 const hole = computed(() => parseInt(route.params.holeId as string))
 
+// Guard gegen ungültige Loch-Nummern in der URL (z. B. /games/:id/NaN aus einem
+// veralteten Link oder einer korrupten Weiter-Navigation). Ohne diese Umleitung
+// landet NaN über saveScore in der holes-Liste und die Scorecard zeigt eine
+// "NaN"-Kachel für ein nie gespieltes Loch.
+watch(hole, (h) => {
+  if (Number.isInteger(h) && h >= VALIDATION.HOLE_MIN && h <= VALIDATION.HOLE_MAX) return
+  const safe = Number.isFinite(h)
+    ? Math.min(VALIDATION.HOLE_MAX, Math.max(VALIDATION.HOLE_MIN, h))
+    : VALIDATION.HOLE_MIN
+  void router.replace(`/games/${gameId.value}/${safe}`)
+}, { immediate: true })
+
 const context = inject(gamesDetailKey)!
 const { players, scores, holes, gameName, lockedScores } = context
 const { saveScore: saveScoreOffline } = useScoreSyncStore()
@@ -399,7 +411,7 @@ async function saveScore(playerId: string) {
     // Erst NACHDEM ein Score gespeichert ist, tauchen wir das Loch in der
     // geteilten holes-Liste auf — so erscheint ein "weitergeblättertes" Loch
     // OHNE eingegebenen Score weder in der Scorecard noch im Pill-Strip.
-    if (!holes.value.includes(hole.value)) {
+    if (Number.isInteger(hole.value) && !holes.value.includes(hole.value)) {
       holes.value = [...holes.value, hole.value].sort((a, b) => a - b)
     }
   } finally {

--- a/frontend/src/components/layout/SettingsSheet.vue
+++ b/frontend/src/components/layout/SettingsSheet.vue
@@ -288,8 +288,8 @@ async function saveName() {
   if (!name || savingName.value) return
   savingName.value = true
   try {
-    const count = await auth.setDisplayName(name)
-    success(count > 0 ? t('Auth.NameClaimed', { count }) : t('Auth.NameSaved'))
+    await auth.setDisplayName(name)
+    success(t('Auth.NameSaved'))
     panel.value = 'root'
   } finally {
     savingName.value = false

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -259,6 +259,8 @@
       "StartGame": "Spiel starten",
       "AddPlayer": "Spieler hinzufügen",
       "RemovePlayer": "Spieler entfernen",
+      "You": "Du",
+      "AddYou": "Das bin ich",
       "Errors": {
         "GameAndPlayerRequired": "Bitte Spielname und mindestens einen Spieler angeben.",
         "SaveFailed": "Fehler beim Speichern des Spiels.",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -261,6 +261,10 @@
       "RemovePlayer": "Spieler entfernen",
       "You": "Du",
       "AddYou": "Das bin ich",
+      "Registered": "Registriert",
+      "SearchRegistered": "Registrierten Spieler suchen",
+      "SearchPlaceholder": "Name eingeben …",
+      "SearchEmpty": "Keine registrierten Spieler gefunden.",
       "Errors": {
         "GameAndPlayerRequired": "Bitte Spielname und mindestens einen Spieler angeben.",
         "SaveFailed": "Fehler beim Speichern des Spiels.",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -262,9 +262,7 @@
       "You": "Du",
       "AddYou": "Das bin ich",
       "Registered": "Registriert",
-      "SearchRegistered": "Registrierten Spieler suchen",
-      "SearchPlaceholder": "Name eingeben …",
-      "SearchEmpty": "Keine registrierten Spieler gefunden.",
+      "SearchHint": "Tipp: Beim Tippen eines Namens werden registrierte Spieler vorgeschlagen.",
       "Errors": {
         "GameAndPlayerRequired": "Bitte Spielname und mindestens einen Spieler angeben.",
         "SaveFailed": "Fehler beim Speichern des Spiels.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -259,6 +259,8 @@
       "StartGame": "Start Game",
       "AddPlayer": "Add Player",
       "RemovePlayer": "Remove player",
+      "You": "You",
+      "AddYou": "This is me",
       "Errors": {
         "GameAndPlayerRequired": "Please enter a game name and at least one player.",
         "SaveFailed": "Failed to save the game.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -261,6 +261,10 @@
       "RemovePlayer": "Remove player",
       "You": "You",
       "AddYou": "This is me",
+      "Registered": "Registered",
+      "SearchRegistered": "Find registered player",
+      "SearchPlaceholder": "Type a name …",
+      "SearchEmpty": "No registered players found.",
       "Errors": {
         "GameAndPlayerRequired": "Please enter a game name and at least one player.",
         "SaveFailed": "Failed to save the game.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -262,9 +262,7 @@
       "You": "You",
       "AddYou": "This is me",
       "Registered": "Registered",
-      "SearchRegistered": "Find registered player",
-      "SearchPlaceholder": "Type a name …",
-      "SearchEmpty": "No registered players found.",
+      "SearchHint": "Tip: registered players are suggested as you type a name.",
       "Errors": {
         "GameAndPlayerRequired": "Please enter a game name and at least one player.",
         "SaveFailed": "Failed to save the game.",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -259,6 +259,8 @@
       "StartGame": "Démarrer la partie",
       "AddPlayer": "Ajouter un joueur",
       "RemovePlayer": "Retirer le joueur",
+      "You": "Toi",
+      "AddYou": "C'est moi",
       "Errors": {
         "GameAndPlayerRequired": "Veuillez saisir un nom de partie et au moins un joueur.",
         "SaveFailed": "Échec de l'enregistrement de la partie.",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -261,6 +261,10 @@
       "RemovePlayer": "Retirer le joueur",
       "You": "Toi",
       "AddYou": "C'est moi",
+      "Registered": "Enregistré",
+      "SearchRegistered": "Chercher un joueur enregistré",
+      "SearchPlaceholder": "Saisir un nom …",
+      "SearchEmpty": "Aucun joueur enregistré trouvé.",
       "Errors": {
         "GameAndPlayerRequired": "Veuillez saisir un nom de partie et au moins un joueur.",
         "SaveFailed": "Échec de l'enregistrement de la partie.",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -262,9 +262,7 @@
       "You": "Toi",
       "AddYou": "C'est moi",
       "Registered": "Enregistré",
-      "SearchRegistered": "Chercher un joueur enregistré",
-      "SearchPlaceholder": "Saisir un nom …",
-      "SearchEmpty": "Aucun joueur enregistré trouvé.",
+      "SearchHint": "Astuce : les joueurs enregistrés sont suggérés au fil de la saisie.",
       "Errors": {
         "GameAndPlayerRequired": "Veuillez saisir un nom de partie et au moins un joueur.",
         "SaveFailed": "Échec de l'enregistrement de la partie.",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -261,6 +261,10 @@
       "RemovePlayer": "Speler verwijderen",
       "You": "Jij",
       "AddYou": "Dat ben ik",
+      "Registered": "Geregistreerd",
+      "SearchRegistered": "Geregistreerde speler zoeken",
+      "SearchPlaceholder": "Voer een naam in …",
+      "SearchEmpty": "Geen geregistreerde spelers gevonden.",
       "Errors": {
         "GameAndPlayerRequired": "Voer een spelnaam en minimaal één speler in.",
         "SaveFailed": "Fout bij het opslaan van het spel.",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -262,9 +262,7 @@
       "You": "Jij",
       "AddYou": "Dat ben ik",
       "Registered": "Geregistreerd",
-      "SearchRegistered": "Geregistreerde speler zoeken",
-      "SearchPlaceholder": "Voer een naam in …",
-      "SearchEmpty": "Geen geregistreerde spelers gevonden.",
+      "SearchHint": "Tip: geregistreerde spelers worden voorgesteld terwijl je een naam typt.",
       "Errors": {
         "GameAndPlayerRequired": "Voer een spelnaam en minimaal één speler in.",
         "SaveFailed": "Fout bij het opslaan van het spel.",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -259,6 +259,8 @@
       "StartGame": "Spel starten",
       "AddPlayer": "Speler toevoegen",
       "RemovePlayer": "Speler verwijderen",
+      "You": "Jij",
+      "AddYou": "Dat ben ik",
       "Errors": {
         "GameAndPlayerRequired": "Voer een spelnaam en minimaal één speler in.",
         "SaveFailed": "Fout bij het opslaan van het spel.",

--- a/frontend/src/pages/games/GamesNewPage.vue
+++ b/frontend/src/pages/games/GamesNewPage.vue
@@ -57,14 +57,32 @@
                 <span class="new-game__self-name">{{ player.name }}</span>
                 <CheckBadgeIcon class="new-game__registered-icon" :aria-label="$t('Games.NewGame.Registered')" />
               </div>
-              <input
-                v-else
-                type="text"
-                v-model="player.name"
-                :placeholder="$t('Games.NewGame.PlayerNamePlaceholder')"
-                maxlength="30"
-                class="field new-game__player-input"
-              />
+              <div v-else class="new-game__input-wrap">
+                <input
+                  type="text"
+                  v-model="player.name"
+                  :placeholder="$t('Games.NewGame.PlayerNamePlaceholder')"
+                  maxlength="30"
+                  class="field new-game__player-input"
+                  autocomplete="off"
+                  @focus="onNameFocus(player)"
+                  @input="onNameInput(player)"
+                />
+                <ul v-if="searchRowId === player.id && suggestions.length" class="new-game__suggest">
+                  <li v-for="r in suggestions" :key="r.id">
+                    <button
+                      type="button"
+                      class="new-game__suggest-item"
+                      @mousedown.prevent
+                      @click="selectRegistered(player, r)"
+                    >
+                      <PlayerAvatar :name="r.name" :src="r.avatar" size="xs" color="var(--color-player-3)" />
+                      <span class="new-game__suggest-name">{{ r.name }}</span>
+                      <CheckBadgeIcon class="new-game__suggest-badge" :aria-label="$t('Games.NewGame.Registered')" />
+                    </button>
+                  </li>
+                </ul>
+              </div>
 
               <button
                 type="button"
@@ -78,51 +96,15 @@
             </li>
           </transition-group>
 
-          <div class="new-game__extra-actions">
-            <button
-              v-if="canAddSelf"
-              type="button"
-              class="new-game__add-self"
-              @click="addSelfRow"
-            >
-              <UserIcon class="w-4 h-4" />
-              {{ $t('Games.NewGame.AddYou') }}
-            </button>
-
-            <button
-              v-if="!searchOpen"
-              type="button"
-              class="new-game__add-self"
-              @click="searchOpen = true"
-            >
-              <UserPlusIcon class="w-4 h-4" />
-              {{ $t('Games.NewGame.SearchRegistered') }}
-            </button>
-          </div>
-
-          <div v-if="searchOpen" class="new-game__search">
-            <div class="new-game__search-field">
-              <MagnifyingGlassIcon class="w-4 h-4 new-game__search-icon" />
-              <input
-                v-model="searchTerm"
-                type="text"
-                class="field new-game__search-input"
-                :placeholder="$t('Games.NewGame.SearchPlaceholder')"
-              />
-            </div>
-            <ul v-if="searchResults.length" class="new-game__results">
-              <li v-for="r in searchResults" :key="r.id">
-                <button type="button" class="new-game__result" @click="addRegistered(r)">
-                  <PlayerAvatar :name="r.name" :src="r.avatar" size="sm" color="var(--color-player-3)" />
-                  <span class="new-game__result-name">{{ r.name }}</span>
-                  <PlusIcon class="w-4 h-4" />
-                </button>
-              </li>
-            </ul>
-            <p v-else-if="searchTerm.trim().length >= 2 && !searching" class="t-muted new-game__search-empty">
-              {{ $t('Games.NewGame.SearchEmpty') }}
-            </p>
-          </div>
+          <button
+            v-if="canAddSelf"
+            type="button"
+            class="new-game__add-self"
+            @click="addSelfRow"
+          >
+            <UserIcon class="w-4 h-4" />
+            {{ $t('Games.NewGame.AddYou') }}
+          </button>
 
           <AppButton
             variant="secondary"
@@ -137,6 +119,8 @@
             </template>
             {{ $t('Games.NewGame.AddPlayer') }}
           </AppButton>
+
+          <p class="t-muted new-game__hint">{{ $t('Games.NewGame.SearchHint') }}</p>
         </div>
       </section>
 
@@ -169,7 +153,7 @@ import { useI18n } from 'vue-i18n'
 import { nanoid } from 'nanoid'
 import { useToast } from '@/composables/useToast'
 import { fetchGame, fetchGamePlayers, createOrUpdatePlayers, createOrUpdateGame, searchPlayers, type RegisteredPlayer } from '@/services/api'
-import { PlusIcon, TrashIcon, PlayIcon, CheckIcon, UserIcon, UserPlusIcon, MagnifyingGlassIcon, CheckBadgeIcon } from '@heroicons/vue/24/outline'
+import { PlusIcon, TrashIcon, PlayIcon, CheckIcon, UserIcon, CheckBadgeIcon } from '@heroicons/vue/24/outline'
 import PlayerAvatar from '@/components/ui/PlayerAvatar.vue'
 import { useAuthStore } from '@/stores/auth'
 
@@ -220,48 +204,47 @@ function addSelfRow() {
   }
 }
 
-// ---- Spielersuche (Phase 2): registrierte Spieler hinzufügen ----
-const searchOpen = ref(false)
-const searchTerm = ref('')
-const searchResults = ref<RegisteredPlayer[]>([])
-const searching = ref(false)
+// ---- Spielersuche (Phase 2): Autocomplete in der Namenseingabe ----
+// Beim Tippen eines Spielernamens werden passende registrierte Spieler als
+// Vorschlag eingeblendet. Auswählen verknüpft die kanonische Identität;
+// nichts auswählen lässt die Zeile ein Freitext-Gast bleiben.
+const searchRowId = ref<string | null>(null)
+const suggestions = ref<RegisteredPlayer[]>([])
 let searchTimer: ReturnType<typeof setTimeout> | undefined
 
-watch(searchTerm, (term) => {
+function onNameFocus(row: Row) {
+  searchRowId.value = row.id
+  suggestions.value = []
+}
+
+function onNameInput(row: Row) {
+  searchRowId.value = row.id
   clearTimeout(searchTimer)
-  const q = term.trim()
+  const q = row.name.trim()
   if (q.length < 2) {
-    searchResults.value = []
-    searching.value = false
+    suggestions.value = []
     return
   }
-  searching.value = true
   searchTimer = setTimeout(async () => {
+    // Zwischenzeitlicher Fokuswechsel? Dann nichts anzeigen.
+    if (searchRowId.value !== row.id) return
     try {
       const results = await searchPlayers(q)
-      // Bereits im Spiel befindliche IDs ausblenden.
       const present = new Set(players.value.map((p) => p.id))
-      searchResults.value = results.filter((r) => !present.has(r.id))
+      suggestions.value = results.filter((r) => !present.has(r.id))
     } catch {
-      searchResults.value = []
-    } finally {
-      searching.value = false
+      suggestions.value = []
     }
   }, 250)
-})
+}
 
-function addRegistered(p: RegisteredPlayer) {
-  if (players.value.some((x) => x.id === p.id)) return
-  const row: Row = { id: p.id, name: p.name, registered: true, avatar: p.avatar }
-  // Eine noch leere Freitext-Einzelzeile ersetzen, sonst anhängen.
-  if (players.value.length === 1 && players.value[0].name === '' && !players.value[0].registered) {
-    players.value = [row]
-  } else {
-    players.value.push(row)
-  }
-  searchTerm.value = ''
-  searchResults.value = []
-  searchOpen.value = false
+function selectRegistered(row: Row, r: RegisteredPlayer) {
+  suggestions.value = []
+  searchRowId.value = null
+  if (players.value.some((x) => x.id === r.id)) return
+  const idx = players.value.findIndex((p) => p.id === row.id)
+  if (idx === -1) return
+  players.value.splice(idx, 1, { id: r.id, name: r.name, registered: true, avatar: r.avatar })
 }
 
 // Beim Öffnen eines neuen Spiels die „Du"-Zeile automatisch anbieten.
@@ -463,17 +446,12 @@ async function saveGame() {
   color: color-mix(in oklab, var(--player-accent) 75%, var(--text-strong));
 }
 
-.new-game__extra-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
 .new-game__add-self {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
+  align-self: flex-start;
   padding: 0.4rem 0.85rem;
   border-radius: var(--radius-pill);
   border: 1px dashed var(--card-border);
@@ -485,50 +463,52 @@ async function saveGame() {
 }
 .new-game__add-self:hover { color: var(--primary); border-color: var(--primary); }
 
-.new-game__search {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
+.new-game__hint { font-size: var(--text-xs); margin-top: -0.5rem; }
 
-.new-game__search-field { position: relative; display: flex; align-items: center; }
-.new-game__search-icon {
+/* Autocomplete: Vorschläge registrierter Spieler unter der Namenseingabe. */
+.new-game__input-wrap { position: relative; min-width: 0; }
+
+.new-game__suggest {
   position: absolute;
-  left: 0.75rem;
-  color: var(--text-muted);
-  pointer-events: none;
-}
-.new-game__search-input { width: 100%; padding-left: 2.25rem; }
-
-.new-game__results {
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 20;
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0.25rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.15rem;
+  background: var(--card-bg);
   border: 1px solid var(--card-border);
   border-radius: var(--radius-md);
-  overflow: hidden;
+  box-shadow: var(--shadow-elev-2);
+  max-height: 14rem;
+  overflow-y: auto;
 }
 
-.new-game__result {
+.new-game__suggest-item {
   display: flex;
   align-items: center;
   gap: 0.6rem;
   width: 100%;
-  padding: 0.55rem 0.75rem;
-  background: transparent;
+  padding: 0.5rem 0.6rem;
   border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
   color: var(--text-default);
   cursor: pointer;
   transition: background 150ms;
 }
-.new-game__result:hover { background: color-mix(in oklab, var(--text-default) 6%, transparent); }
-.new-game__result-name { flex: 1 1 auto; text-align: left; font-weight: 600; font-size: var(--text-sm); }
-.new-game__result :deep(svg:last-child) { color: var(--text-muted); flex-shrink: 0; }
-
-.new-game__search-empty { font-size: var(--text-sm); padding: 0.25rem 0.25rem 0; }
+.new-game__suggest-item:hover { background: color-mix(in oklab, var(--text-default) 7%, transparent); }
+.new-game__suggest-name { flex: 1 1 auto; text-align: left; font-weight: 600; font-size: var(--text-sm); }
+.new-game__suggest-badge {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex-shrink: 0;
+  color: color-mix(in oklab, var(--color-player-3) 80%, var(--text-strong));
+}
 
 .new-game__remove {
   width: 2.5rem;

--- a/frontend/src/pages/games/GamesNewPage.vue
+++ b/frontend/src/pages/games/GamesNewPage.vue
@@ -32,16 +32,30 @@
               v-for="(player, index) in players"
               :key="player.id"
               class="new-game__player"
+              :class="{ 'new-game__player--self': isSelf(player) }"
               :style="{ '--player-accent': playerColor(index) }"
             >
               <span class="new-game__player-index">{{ index + 1 }}</span>
+
+              <div v-if="isSelf(player)" class="new-game__self">
+                <PlayerAvatar
+                  :name="player.name || $t('Games.NewGame.You')"
+                  :src="auth.avatar"
+                  size="sm"
+                  :color="playerColor(index)"
+                />
+                <span class="new-game__self-name">{{ player.name }}</span>
+                <span class="new-game__self-badge">{{ $t('Games.NewGame.You') }}</span>
+              </div>
               <input
+                v-else
                 type="text"
                 v-model="player.name"
                 :placeholder="$t('Games.NewGame.PlayerNamePlaceholder')"
                 maxlength="30"
                 class="field new-game__player-input"
               />
+
               <button
                 type="button"
                 class="new-game__remove"
@@ -53,6 +67,16 @@
               </button>
             </li>
           </transition-group>
+
+          <button
+            v-if="canAddSelf"
+            type="button"
+            class="new-game__add-self"
+            @click="addSelfRow"
+          >
+            <UserIcon class="w-4 h-4" />
+            {{ $t('Games.NewGame.AddYou') }}
+          </button>
 
           <AppButton
             variant="secondary"
@@ -99,7 +123,8 @@ import { useI18n } from 'vue-i18n'
 import { nanoid } from 'nanoid'
 import { useToast } from '@/composables/useToast'
 import { fetchGame, fetchGamePlayers, createOrUpdatePlayers, createOrUpdateGame } from '@/services/api'
-import { PlusIcon, TrashIcon, PlayIcon, CheckIcon } from '@heroicons/vue/24/outline'
+import { PlusIcon, TrashIcon, PlayIcon, CheckIcon, UserIcon } from '@heroicons/vue/24/outline'
+import PlayerAvatar from '@/components/ui/PlayerAvatar.vue'
 import { useAuthStore } from '@/stores/auth'
 
 const router = useRouter()
@@ -114,18 +139,33 @@ const players = ref([{ id: nanoid(), name: '' }])
 const isEditing = computed(() => !!gameId.value)
 const isSaving = ref(false)
 
-// Namensvorschlag: bei einem neuen Spiel den eigenen Namen als ersten Spieler
-// vorschlagen — nur einmal und nur, wenn das Feld noch leer ist.
-let nameSuggested = false
-function suggestOwnName() {
-  if (nameSuggested || isEditing.value) return
-  if (auth.displayName && players.value[0] && players.value[0].name === '') {
-    players.value[0].name = auth.displayName
-    nameSuggested = true
+// Selbst-Markierung: ist der Nutzer eingeloggt mit kanonischer Identität,
+// wird die erste Zeile zur „Du"-Zeile — mit der stabilen Spieler-ID, damit
+// die Runde spielübergreifend korrekt der eigenen Statistik zugeordnet wird.
+// Der Name bleibt read-only (Änderung nur im Profil, sonst würde die kanonische
+// Identität versehentlich umbenannt). Optional: entfernbar (Scorekeeper) und
+// wieder hinzufügbar.
+function isSelf(player: { id: string }) {
+  return !!auth.playerId && player.id === auth.playerId
+}
+
+const hasSelfRow = computed(() => players.value.some(isSelf))
+const canAddSelf = computed(() => !isEditing.value && !!auth.playerId && !hasSelfRow.value)
+
+function addSelfRow() {
+  if (!auth.playerId || hasSelfRow.value) return
+  const meRow = { id: auth.playerId, name: auth.displayName || '' }
+  // Eine noch leere Einzelzeile ersetzen, sonst voranstellen.
+  if (players.value.length === 1 && players.value[0].name === '' && !isSelf(players.value[0])) {
+    players.value = [meRow]
+  } else {
+    players.value.unshift(meRow)
   }
 }
-onMounted(suggestOwnName)
-watch(() => auth.displayName, suggestOwnName)
+
+// Beim Öffnen eines neuen Spiels die „Du"-Zeile automatisch anbieten.
+onMounted(() => { if (canAddSelf.value) addSelfRow() })
+watch(() => auth.playerId, () => { if (canAddSelf.value) addSelfRow() })
 
 async function loadGame(id: string) {
   try {
@@ -274,6 +314,57 @@ async function saveGame() {
 }
 
 .new-game__player-input { padding-block: 0.65rem; }
+
+/* „Du"-Zeile: eigene Identität, Name nicht editierbar (nur im Profil änderbar). */
+.new-game__self {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+  padding: 0.4rem 0.6rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed color-mix(in oklab, var(--player-accent) 45%, transparent);
+  background: color-mix(in oklab, var(--player-accent) 8%, transparent);
+}
+
+.new-game__self-name {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.new-game__self-badge {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--player-accent) 75%, var(--text-strong));
+  background: color-mix(in oklab, var(--player-accent) 18%, transparent);
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-pill);
+}
+
+.new-game__add-self {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  align-self: flex-start;
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius-pill);
+  border: 1px dashed var(--card-border);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  transition: color 150ms, border-color 150ms;
+}
+.new-game__add-self:hover { color: var(--primary); border-color: var(--primary); }
 
 .new-game__remove {
   width: 2.5rem;

--- a/frontend/src/pages/games/GamesNewPage.vue
+++ b/frontend/src/pages/games/GamesNewPage.vue
@@ -47,6 +47,16 @@
                 <span class="new-game__self-name">{{ player.name }}</span>
                 <span class="new-game__self-badge">{{ $t('Games.NewGame.You') }}</span>
               </div>
+              <div v-else-if="isRegistered(player)" class="new-game__self new-game__self--registered">
+                <PlayerAvatar
+                  :name="player.name"
+                  :src="player.avatar"
+                  size="sm"
+                  :color="playerColor(index)"
+                />
+                <span class="new-game__self-name">{{ player.name }}</span>
+                <CheckBadgeIcon class="new-game__registered-icon" :aria-label="$t('Games.NewGame.Registered')" />
+              </div>
               <input
                 v-else
                 type="text"
@@ -68,15 +78,51 @@
             </li>
           </transition-group>
 
-          <button
-            v-if="canAddSelf"
-            type="button"
-            class="new-game__add-self"
-            @click="addSelfRow"
-          >
-            <UserIcon class="w-4 h-4" />
-            {{ $t('Games.NewGame.AddYou') }}
-          </button>
+          <div class="new-game__extra-actions">
+            <button
+              v-if="canAddSelf"
+              type="button"
+              class="new-game__add-self"
+              @click="addSelfRow"
+            >
+              <UserIcon class="w-4 h-4" />
+              {{ $t('Games.NewGame.AddYou') }}
+            </button>
+
+            <button
+              v-if="!searchOpen"
+              type="button"
+              class="new-game__add-self"
+              @click="searchOpen = true"
+            >
+              <UserPlusIcon class="w-4 h-4" />
+              {{ $t('Games.NewGame.SearchRegistered') }}
+            </button>
+          </div>
+
+          <div v-if="searchOpen" class="new-game__search">
+            <div class="new-game__search-field">
+              <MagnifyingGlassIcon class="w-4 h-4 new-game__search-icon" />
+              <input
+                v-model="searchTerm"
+                type="text"
+                class="field new-game__search-input"
+                :placeholder="$t('Games.NewGame.SearchPlaceholder')"
+              />
+            </div>
+            <ul v-if="searchResults.length" class="new-game__results">
+              <li v-for="r in searchResults" :key="r.id">
+                <button type="button" class="new-game__result" @click="addRegistered(r)">
+                  <PlayerAvatar :name="r.name" :src="r.avatar" size="sm" color="var(--color-player-3)" />
+                  <span class="new-game__result-name">{{ r.name }}</span>
+                  <PlusIcon class="w-4 h-4" />
+                </button>
+              </li>
+            </ul>
+            <p v-else-if="searchTerm.trim().length >= 2 && !searching" class="t-muted new-game__search-empty">
+              {{ $t('Games.NewGame.SearchEmpty') }}
+            </p>
+          </div>
 
           <AppButton
             variant="secondary"
@@ -122,10 +168,17 @@ import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { nanoid } from 'nanoid'
 import { useToast } from '@/composables/useToast'
-import { fetchGame, fetchGamePlayers, createOrUpdatePlayers, createOrUpdateGame } from '@/services/api'
-import { PlusIcon, TrashIcon, PlayIcon, CheckIcon, UserIcon } from '@heroicons/vue/24/outline'
+import { fetchGame, fetchGamePlayers, createOrUpdatePlayers, createOrUpdateGame, searchPlayers, type RegisteredPlayer } from '@/services/api'
+import { PlusIcon, TrashIcon, PlayIcon, CheckIcon, UserIcon, UserPlusIcon, MagnifyingGlassIcon, CheckBadgeIcon } from '@heroicons/vue/24/outline'
 import PlayerAvatar from '@/components/ui/PlayerAvatar.vue'
 import { useAuthStore } from '@/stores/auth'
+
+interface Row {
+  id: string
+  name: string
+  registered?: boolean
+  avatar?: string | null
+}
 
 const router = useRouter()
 const route = useRoute()
@@ -135,7 +188,7 @@ const auth = useAuthStore()
 const gameId = computed(() => route.params.gameId as string | undefined)
 
 const gameName = ref('')
-const players = ref([{ id: nanoid(), name: '' }])
+const players = ref<Row[]>([{ id: nanoid(), name: '' }])
 const isEditing = computed(() => !!gameId.value)
 const isSaving = ref(false)
 
@@ -152,15 +205,63 @@ function isSelf(player: { id: string }) {
 const hasSelfRow = computed(() => players.value.some(isSelf))
 const canAddSelf = computed(() => !isEditing.value && !!auth.playerId && !hasSelfRow.value)
 
+function isRegistered(player: Row) {
+  return !!player.registered && !isSelf(player)
+}
+
 function addSelfRow() {
   if (!auth.playerId || hasSelfRow.value) return
-  const meRow = { id: auth.playerId, name: auth.displayName || '' }
+  const meRow: Row = { id: auth.playerId, name: auth.displayName || '', registered: true, avatar: auth.avatar }
   // Eine noch leere Einzelzeile ersetzen, sonst voranstellen.
   if (players.value.length === 1 && players.value[0].name === '' && !isSelf(players.value[0])) {
     players.value = [meRow]
   } else {
     players.value.unshift(meRow)
   }
+}
+
+// ---- Spielersuche (Phase 2): registrierte Spieler hinzufügen ----
+const searchOpen = ref(false)
+const searchTerm = ref('')
+const searchResults = ref<RegisteredPlayer[]>([])
+const searching = ref(false)
+let searchTimer: ReturnType<typeof setTimeout> | undefined
+
+watch(searchTerm, (term) => {
+  clearTimeout(searchTimer)
+  const q = term.trim()
+  if (q.length < 2) {
+    searchResults.value = []
+    searching.value = false
+    return
+  }
+  searching.value = true
+  searchTimer = setTimeout(async () => {
+    try {
+      const results = await searchPlayers(q)
+      // Bereits im Spiel befindliche IDs ausblenden.
+      const present = new Set(players.value.map((p) => p.id))
+      searchResults.value = results.filter((r) => !present.has(r.id))
+    } catch {
+      searchResults.value = []
+    } finally {
+      searching.value = false
+    }
+  }, 250)
+})
+
+function addRegistered(p: RegisteredPlayer) {
+  if (players.value.some((x) => x.id === p.id)) return
+  const row: Row = { id: p.id, name: p.name, registered: true, avatar: p.avatar }
+  // Eine noch leere Freitext-Einzelzeile ersetzen, sonst anhängen.
+  if (players.value.length === 1 && players.value[0].name === '' && !players.value[0].registered) {
+    players.value = [row]
+  } else {
+    players.value.push(row)
+  }
+  searchTerm.value = ''
+  searchResults.value = []
+  searchOpen.value = false
 }
 
 // Beim Öffnen eines neuen Spiels die „Du"-Zeile automatisch anbieten.
@@ -172,7 +273,7 @@ async function loadGame(id: string) {
     const game = await fetchGame(id)
     gameName.value = game?.name || ''
     const existing = await fetchGamePlayers(id)
-    players.value = existing.map(p => ({ id: p.id, name: p.name }))
+    players.value = existing.map(p => ({ id: p.id, name: p.name, registered: p.registered, avatar: p.avatar }))
     if (players.value.length === 0) players.value = [{ id: nanoid(), name: '' }]
   } catch (err) {
     console.error('Failed to load game:', err)
@@ -349,12 +450,30 @@ async function saveGame() {
   border-radius: var(--radius-pill);
 }
 
+.new-game__self--registered {
+  border-style: solid;
+  border-color: color-mix(in oklab, var(--player-accent) 30%, transparent);
+}
+
+.new-game__registered-icon {
+  width: 1.15rem;
+  height: 1.15rem;
+  margin-left: auto;
+  flex-shrink: 0;
+  color: color-mix(in oklab, var(--player-accent) 75%, var(--text-strong));
+}
+
+.new-game__extra-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .new-game__add-self {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
-  align-self: flex-start;
   padding: 0.4rem 0.85rem;
   border-radius: var(--radius-pill);
   border: 1px dashed var(--card-border);
@@ -365,6 +484,51 @@ async function saveGame() {
   transition: color 150ms, border-color 150ms;
 }
 .new-game__add-self:hover { color: var(--primary); border-color: var(--primary); }
+
+.new-game__search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.new-game__search-field { position: relative; display: flex; align-items: center; }
+.new-game__search-icon {
+  position: absolute;
+  left: 0.75rem;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+.new-game__search-input { width: 100%; padding-left: 2.25rem; }
+
+.new-game__results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.new-game__result {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  background: transparent;
+  border: 0;
+  color: var(--text-default);
+  cursor: pointer;
+  transition: background 150ms;
+}
+.new-game__result:hover { background: color-mix(in oklab, var(--text-default) 6%, transparent); }
+.new-game__result-name { flex: 1 1 auto; text-align: left; font-weight: 600; font-size: var(--text-sm); }
+.new-game__result :deep(svg:last-child) { color: var(--text-muted); flex-shrink: 0; }
+
+.new-game__search-empty { font-size: var(--text-sm); padding: 0.25rem 0.25rem 0; }
 
 .new-game__remove {
   width: 2.5rem;

--- a/frontend/src/pages/games/GamesNewPage.vue
+++ b/frontend/src/pages/games/GamesNewPage.vue
@@ -371,21 +371,22 @@ async function saveGame() {
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.5rem;
 }
 
 .new-game__player {
   --player-accent: var(--color-player-1);
+  --row-h: 3rem;
   display: grid;
-  grid-template-columns: 2rem 1fr auto;
+  grid-template-columns: 2.25rem 1fr auto;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.6rem;
   position: relative;
 }
 
 .new-game__player-index {
-  width: 2rem;
-  height: 2rem;
+  width: 2.25rem;
+  height: 2.25rem;
   border-radius: 999px;
   background: color-mix(in oklab, var(--player-accent) 18%, transparent);
   color: color-mix(in oklab, var(--player-accent) 70%, var(--text-strong));
@@ -397,15 +398,20 @@ async function saveGame() {
   border: 1px solid color-mix(in oklab, var(--player-accent) 30%, transparent);
 }
 
-.new-game__player-input { padding-block: 0.65rem; }
+.new-game__player-input {
+  min-height: var(--row-h);
+  padding-block: 0.5rem;
+}
 
-/* „Du"-Zeile: eigene Identität, Name nicht editierbar (nur im Profil änderbar). */
+/* „Du"-Zeile: eigene Identität, Name nicht editierbar (nur im Profil änderbar).
+   Gleiche Höhe wie die Eingabefelder für ein ruhiges Listenbild. */
 .new-game__self {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 0.6rem;
   min-width: 0;
-  padding: 0.4rem 0.6rem;
+  min-height: var(--row-h);
+  padding: 0 0.75rem;
   border-radius: var(--radius-md);
   border: 1px dashed color-mix(in oklab, var(--player-accent) 45%, transparent);
   background: color-mix(in oklab, var(--player-accent) 8%, transparent);
@@ -463,7 +469,7 @@ async function saveGame() {
 }
 .new-game__add-self:hover { color: var(--primary); border-color: var(--primary); }
 
-.new-game__hint { font-size: var(--text-xs); margin-top: -0.5rem; }
+.new-game__hint { font-size: var(--text-xs); margin-top: 0; }
 
 /* Autocomplete: Vorschläge registrierter Spieler unter der Namenseingabe. */
 .new-game__input-wrap { position: relative; min-width: 0; }
@@ -511,8 +517,8 @@ async function saveGame() {
 }
 
 .new-game__remove {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.75rem;
+  height: 2.75rem;
   border-radius: 999px;
   background: transparent;
   border: 1px solid var(--card-border);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -8,6 +8,19 @@ export interface Player {
   name: string
 }
 
+/** Spieler eines Spiels — kanonische (Konto-)Identitäten sind markiert. */
+export interface GamePlayer extends Player {
+  registered?: boolean
+  avatar?: string | null
+}
+
+/** Registrierter Spieler aus der Spielersuche (Konto mit kanonischer Identität). */
+export interface RegisteredPlayer {
+  id: string
+  name: string
+  avatar: string | null
+}
+
 export interface PlayerWithStats extends Player {
   avg: number | null
   total: number | null
@@ -65,9 +78,18 @@ export async function fetchGame(gameId: string): Promise<Game> {
   return data
 }
 
-export async function fetchGamePlayers(gameId: string): Promise<Player[]> {
-  const { data } = await axios.get<Player[]>(`${API_ROUTES.GAMES}/${gameId}/players`)
+export async function fetchGamePlayers(gameId: string): Promise<GamePlayer[]> {
+  const { data } = await axios.get<GamePlayer[]>(`${API_ROUTES.GAMES}/${gameId}/players`)
   return data
+}
+
+/** Registrierte Spieler nach Name suchen (für die Spielersuche beim Erstellen). */
+export async function searchPlayers(q: string): Promise<RegisteredPlayer[]> {
+  const { data } = await axios.get<{ players: RegisteredPlayer[] }>(
+    `${API_ROUTES.PLAYERS}/search`,
+    { params: { q } },
+  )
+  return data.players
 }
 
 export async function createOrUpdateGame(payload: {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -128,6 +128,9 @@ export interface Account {
   email: string
   displayName: string | null
   avatar: string | null
+  // Kanonische Selbst-Identität: stabile Spieler-ID des Kontos (für die
+  // „Das bin ich"-Zeile beim Erstellen eines Spiels wiederverwendet).
+  playerId: string | null
 }
 
 export async function requestOtp(email: string): Promise<void> {
@@ -153,12 +156,12 @@ export async function logout(): Promise<void> {
   await axios.post(`${API_ROUTES.AUTH}/logout`)
 }
 
-export async function setProfile(displayName: string): Promise<{ account: Account; claimedCount: number }> {
-  const { data } = await axios.post<{ account: Account; claimedCount: number }>(
+export async function setProfile(displayName: string): Promise<Account> {
+  const { data } = await axios.post<{ account: Account }>(
     `${API_ROUTES.AUTH}/profile`,
     { displayName },
   )
-  return data
+  return data.account
 }
 
 export async function fetchMyGames(): Promise<GameSummary[]> {

--- a/frontend/src/stores/__tests__/auth.test.ts
+++ b/frontend/src/stores/__tests__/auth.test.ts
@@ -24,7 +24,7 @@ describe('useAuthStore', () => {
   })
 
   it('loadMe restores an existing session', async () => {
-    vi.mocked(fetchMe).mockResolvedValue({ id: 'a1', email: 'a@b.com', displayName: 'Anna', avatar: null })
+    vi.mocked(fetchMe).mockResolvedValue({ id: 'a1', email: 'a@b.com', displayName: 'Anna', avatar: null, playerId: null })
     const s = useAuthStore()
     await s.loadMe()
     expect(s.isLoggedIn).toBe(true)
@@ -48,7 +48,7 @@ describe('useAuthStore', () => {
   })
 
   it('verifyOtp logs in with the returned account', async () => {
-    vi.mocked(verifyOtp).mockResolvedValue({ id: 'a1', email: 'a@b.com', displayName: null, avatar: null })
+    vi.mocked(verifyOtp).mockResolvedValue({ id: 'a1', email: 'a@b.com', displayName: null, avatar: null, playerId: null })
     const s = useAuthStore()
     await s.verifyOtp('a@b.com', '123456')
     expect(s.isLoggedIn).toBe(true)
@@ -63,7 +63,7 @@ describe('useAuthStore', () => {
   })
 
   it('logout clears the account even if the API call is the last step', async () => {
-    vi.mocked(verifyOtp).mockResolvedValue({ id: 'a1', email: 'a@b.com', displayName: null, avatar: null })
+    vi.mocked(verifyOtp).mockResolvedValue({ id: 'a1', email: 'a@b.com', displayName: null, avatar: null, playerId: null })
     const s = useAuthStore()
     await s.verifyOtp('a@b.com', '123456')
     await s.logout()

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -26,6 +26,7 @@ export const useAuthStore = defineStore('auth', () => {
   const isLoggedIn = computed(() => account.value !== null)
   const displayName = computed(() => account.value?.displayName || null)
   const avatar = computed(() => account.value?.avatar || null)
+  const playerId = computed(() => account.value?.playerId || null)
 
   function openLogin() {
     loginOpen.value = true
@@ -57,11 +58,9 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  /** Anzeigename setzen und eigene Spieler-Einträge beanspruchen. */
-  async function setDisplayName(name: string): Promise<number> {
-    const { account: updated, claimedCount } = await apiSetProfile(name)
-    account.value = updated
-    return claimedCount
+  /** Anzeigename setzen. Etabliert die kanonische Selbst-Identität serverseitig. */
+  async function setDisplayName(name: string): Promise<void> {
+    account.value = await apiSetProfile(name)
   }
 
   async function deleteAccount(keepScores: boolean) {
@@ -78,7 +77,7 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   return {
-    account, loaded, loginOpen, isLoggedIn, displayName, avatar,
+    account, loaded, loginOpen, isLoggedIn, displayName, avatar, playerId,
     openLogin, closeLogin, loadMe, requestOtp, verifyOtp, logout,
     setDisplayName, deleteAccount, setAvatar,
   }


### PR DESCRIPTION
Identitäts-Redesign aus PRD #106 — weg vom fragilen namensbasierten Claiming hin zu expliziter Konto-Identität, plus Phase 2 (Spielersuche). Präzision vor Vollständigkeit; anonymes Spielen bleibt erstklassig & reibungslos.

Closes #107
Closes #108
Closes #109
Closes #110
Closes #112

## Slices

**#107 — Spiel-Ownership (`created_by`)** · Migration 007
`POST /games` session-aware, Ersteller serverseitig aus dem Cookie. „Meine Spiele" = `created_by` ∪ Runden mit zugeordnetem Spieler.

**#108 — Kanonische Selbst-Identität** · Migration 008
Ein stabiler Spieler pro Konto (`accounts.player_id`). `profile` legt ihn an/benennt um, setzt `account_players` auf genau diese Zeile — kein Namens-Grabbing, kein `claimedCount`. Stats/H2H/my-games kollisionsfrei.

**#109 — Selbst-Markierung („Das bin ich")**
Eingeloggt → „Du"-Zeile mit kanonischer ID (read-only Name), optional, anonym unverändert.

**#110 — Cutover-Migration** · Migration 009
`account_players` in Dev + Prod bewusst geleert.

**#112 — Spielersuche (Phase 2)**
`GET /api/players/search` (auch ohne Login) findet registrierte Spieler; Hinzufügen legt die kanonische ID ins Spiel → zählt zu deren „Meine Spiele"/Stats. Registrierte Zeilen read-only + badged; `GET /games/:id/players` markiert registrierte Identitäten (Bearbeiten schützt vor Umbenennen).

## Extra
- Bugfix (separater Commit): Guard gegen ungültige Loch-Nummern (`/games/:id/NaN`).

## Tests
Backend **68** · Frontend `test:all` (Lint · Type-Check · Unit · **80 Smoke**) grün. Locale-Parität gewahrt.

## Deployment
Migrationen 007–009 laufen lassen. **#110** setzt `account_players` in Prod bewusst zurück.

## Design-Hinweis / bewusste Trade-offs
- **Auffindbarkeit = Anzeigename gesetzt.** Wer einen Anzeigenamen setzt, wird per Suche auffindbar (implizites Opt-in). Kein separater Sichtbarkeits-Schalter in v1.
- **Direktes Hinzufügen ohne Bestätigung.** Ein Ersteller kann einen registrierten Spieler direkt einem Spiel zuordnen; das erscheint sofort in dessen „Meine Spiele"/Stats. Für den kleinen Freundeskreis unkritisch. Mögliche spätere Safeguards: Opt-in-Findability oder „Pending-Bestätigung" durch den zugeordneten Nutzer.

## Weitere Folgearbeit
Passkey/WebAuthn (#103).
