### PR TITLE
Private Spiele — Phase 2: Zugriffsschutz beim Direktzugriff

### DIFF
--- a/backend/routes/__tests__/games.test.js
+++ b/backend/routes/__tests__/games.test.js
@@ -376,16 +376,35 @@ describe('GET /games/:id', () => {
     expect(body.created_by).toBeUndefined()
   })
 
-  it('reports is_owner=false for anonymous access', async () => {
+  it('denies anonymous access to a private game (403)', async () => {
     createMockClient(() => ({
-      rows: [{ id: 'game1234567890', name: 'Owned', visibility: 'private', created_by: 'acc-1' }],
+      rows: [{ id: 'game1234567890', name: 'Owned', visibility: 'private', created_by: 'acc-1', is_participant: false }],
       rowCount: 1,
     }))
 
     const res = await app.inject({ method: 'GET', url: '/game1234567890' })
 
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('allows a registered participant to access a private game', async () => {
+    createMockClient((sql) => {
+      if (sql.includes('FROM sessions')) {
+        return { rows: [{ id: 'acc-2', email: 'p@b.c', display_name: null, avatar: null }] }
+      }
+      // getGameAccess: fremder Account, aber Teilnehmer (is_participant true).
+      return { rows: [{ id: 'game1234567890', name: 'Shared', visibility: 'private', created_by: 'acc-1', is_participant: true }], rowCount: 1 }
+    })
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/game1234567890',
+      cookies: { ug_session: 'valid-token' },
+    })
+
     expect(res.statusCode).toBe(200)
     expect(res.json().is_owner).toBe(false)
+    expect(res.json().visibility).toBe('private')
   })
 
   it('returns 400 for invalid id', async () => {
@@ -436,5 +455,44 @@ describe('GET /games/:id/players', () => {
     })
 
     expect(res.statusCode).toBe(400)
+  })
+
+  it('denies players of a foreign private game (403)', async () => {
+    createMockClient((sql) => {
+      if (sql.includes('is_participant')) {
+        return { rows: [{ id: 'game1234567890', name: 'Secret', visibility: 'private', created_by: 'acc-1', is_participant: false }] }
+      }
+      return { rows: [] }
+    })
+
+    const res = await app.inject({ method: 'GET', url: '/game1234567890/players' })
+
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('serves players of a private game to its owner', async () => {
+    const client = createMockClient((sql) => {
+      if (sql.includes('FROM sessions')) {
+        return { rows: [{ id: 'acc-1', email: 'o@b.c', display_name: null, avatar: null }] }
+      }
+      if (sql.includes('is_participant')) {
+        return { rows: [{ id: 'game1234567890', name: 'Mine', visibility: 'private', created_by: 'acc-1', is_participant: false }] }
+      }
+      if (sql.includes('AS registered')) {
+        return { rows: [{ id: 'canon-alice-01', name: 'Alice', registered: true, avatar: null }] }
+      }
+      return { rows: [] }
+    })
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/game1234567890/players',
+      cookies: { ug_session: 'valid-token' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toHaveLength(1)
+    const playersCall = client.query.mock.calls.find((c) => c[0].includes('AS registered'))
+    expect(playersCall).toBeDefined()
   })
 })

--- a/backend/routes/__tests__/scores.test.js
+++ b/backend/routes/__tests__/scores.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import Fastify from 'fastify'
+import fastifyCookie from '@fastify/cookie'
 
 import { pgMock } from './_pgMock.js'
 
@@ -21,8 +22,16 @@ function createMockClient(queryImpl) {
 function buildApp() {
   const app = Fastify({ logger: false })
   app.setErrorHandler(handleError)
+  // Cookie-Plugin: nötig, damit die Score-Routen die (optionale) Session lesen
+  // und den Phase-2-Zugriffsschutz privater Spiele prüfen können.
+  app.register(fastifyCookie)
   app.register(scoreRoutes, { prefix: '/' })
   return app
+}
+
+// Mock-Helfer: erste Query ist der getGameAccess-Lookup (enthält is_participant).
+function accessRow({ visibility = 'public', created_by = null, is_participant = false } = {}) {
+  return { rows: [{ id: 'game1234567890', name: 'G', visibility, created_by, is_participant }] }
 }
 
 describe('GET /scores', () => {
@@ -129,5 +138,77 @@ describe('POST /scores', () => {
     })
 
     expect(res.statusCode).toBe(400)
+  })
+})
+
+describe('Scores — Zugriffsschutz private Spiele (Phase 2)', () => {
+  let app
+
+  beforeEach(() => {
+    app = buildApp()
+    getClient.mockReset()
+  })
+
+  afterEach(() => app.close())
+
+  it('denies reading scores of a foreign private game (403)', async () => {
+    createMockClient((sql) => {
+      if (sql.includes('is_participant')) return accessRow({ visibility: 'private', created_by: 'acc-1', is_participant: false })
+      return { rows: [] }
+    })
+
+    const res = await app.inject({ method: 'GET', url: '/?game_id=game1234567890' })
+
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('serves scores of a private game to a participant', async () => {
+    createMockClient((sql) => {
+      if (sql.includes('FROM sessions')) return { rows: [{ id: 'acc-2', email: 'p@b.c', display_name: null, avatar: null }] }
+      if (sql.includes('is_participant')) return accessRow({ visibility: 'private', created_by: 'acc-1', is_participant: true })
+      return { rows: [{ id: 1, game_id: 'game1234567890', player_id: 'p1234567890123', hole: 1, strokes: 3, player_name: 'Alice' }] }
+    })
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/?game_id=game1234567890',
+      cookies: { ug_session: 'valid-token' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toHaveLength(1)
+  })
+
+  it('denies posting a score to a foreign private game (403)', async () => {
+    createMockClient((sql) => {
+      if (sql.includes('is_participant')) return accessRow({ visibility: 'private', created_by: 'acc-1', is_participant: false })
+      return { rows: [{ id: 42 }] }
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/',
+      payload: { game_id: 'game1234567890', player_id: 'player1234567890', hole: 1, strokes: 3 },
+    })
+
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('lets a participant post a score to a private game', async () => {
+    createMockClient((sql) => {
+      if (sql.includes('FROM sessions')) return { rows: [{ id: 'acc-2', email: 'p@b.c', display_name: null, avatar: null }] }
+      if (sql.includes('is_participant')) return accessRow({ visibility: 'private', created_by: 'acc-1', is_participant: true })
+      return { rows: [{ id: 42 }] }
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/',
+      cookies: { ug_session: 'valid-token' },
+      payload: { game_id: 'game1234567890', player_id: 'player1234567890', hole: 1, strokes: 3 },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().id).toBe(42)
   })
 })

--- a/backend/routes/games.js
+++ b/backend/routes/games.js
@@ -1,6 +1,7 @@
-import { query, queryOne, transaction } from '../db/pg.js';
+import { query, transaction } from '../db/pg.js';
 import { schemas, isValidId } from '@urban-golf/contract';
 import { getAccountFromRequest } from '../utils/auth.js';
+import { getGameAccess } from '../utils/gameAccess.js';
 
 /**
  * SQL-Fragment: ein Spiel `g` ist sichtbar, wenn es öffentlich ist ODER der
@@ -153,19 +154,18 @@ export default async function (fastify, _opts) {
     const gameId = req.params.id;
     if (!isValidId(gameId)) return reply.code(400).send({ error: 'Invalid game ID' });
 
-    // Phase 1 (ungelistet): der Direktzugriff bleibt offen — visibility und ein
-    // is_owner-Flag werden mitgeliefert, damit das UI private Runden kennzeichnen
-    // und den Sichtbarkeits-Umschalter nur dem Ersteller anbieten kann. Die
-    // created_by-UUID selbst wird nicht nach aussen gegeben.
+    // Phase 2 (Zugriffsschutz): private Spiele nur für Ersteller/Teilnehmer.
+    // visibility und is_owner werden mitgeliefert, damit das UI private Runden
+    // kennzeichnen kann; die created_by-UUID bleibt intern.
     const account = await getAccountFromRequest(req);
-    const me = account?.id ?? null;
-    const game = await queryOne(`SELECT id, name, visibility, created_by FROM games WHERE id = $1`, [gameId]);
-    if (!game) return reply.code(404).send({ error: 'Not found' });
+    const access = await getGameAccess(gameId, account?.id ?? null);
+    if (!access.exists) return reply.code(404).send({ error: 'Not found' });
+    if (!access.allowed) return reply.code(403).send({ error: 'forbidden' });
     reply.send({
-      id: game.id,
-      name: game.name,
-      visibility: game.visibility,
-      is_owner: me != null && game.created_by === me,
+      id: gameId,
+      name: access.name,
+      visibility: access.visibility,
+      is_owner: access.isOwner,
     });
   });
 
@@ -173,6 +173,12 @@ export default async function (fastify, _opts) {
   fastify.get('/:id/players', async (req, reply) => {
     const gameId = req.params.id;
     if (!isValidId(gameId)) return reply.code(400).send({ error: 'Invalid game ID' });
+
+    // Gleicher Zugriffsschutz wie beim Spiel selbst.
+    const account = await getAccountFromRequest(req);
+    const access = await getGameAccess(gameId, account?.id ?? null);
+    if (!access.exists) return reply.code(404).send({ error: 'Not found' });
+    if (!access.allowed) return reply.code(403).send({ error: 'forbidden' });
 
     const rows = await query(
       // registered/avatar: markiert kanonische (Konto-)Identitäten, damit die

--- a/backend/routes/scores.js
+++ b/backend/routes/scores.js
@@ -1,5 +1,7 @@
 import { query } from '../db/pg.js';
 import { schemas } from '@urban-golf/contract';
+import { getAccountFromRequest } from '../utils/auth.js';
+import { getGameAccess } from '../utils/gameAccess.js';
 
 export default async function (fastify, _opts) {
   fastify.get('/', {
@@ -12,6 +14,12 @@ export default async function (fastify, _opts) {
     },
   }, async (req, reply) => {
     const { game_id: gameId } = req.query;
+
+    // Phase-2-Zugriffsschutz: Scores privater Spiele nur für Ersteller/Teilnehmer.
+    const account = await getAccountFromRequest(req);
+    const access = await getGameAccess(gameId, account?.id ?? null);
+    if (!access.exists) return reply.code(404).send({ error: 'Not found' });
+    if (!access.allowed) return reply.code(403).send({ error: 'forbidden' });
 
     const rows = await query(
       `SELECT s.*, p.name as player_name FROM scores s
@@ -33,6 +41,13 @@ export default async function (fastify, _opts) {
     },
   }, async (req, reply) => {
     const { game_id, player_id, strokes, hole } = req.body;
+
+    // Scores privater Spiele nur von Ersteller/Teilnehmern (kein anonymes
+    // Scoren per geteiltem Link mehr — bewusste Phase-2-Semantik).
+    const account = await getAccountFromRequest(req);
+    const access = await getGameAccess(game_id, account?.id ?? null);
+    if (!access.exists) return reply.code(404).send({ error: 'Not found' });
+    if (!access.allowed) return reply.code(403).send({ error: 'forbidden' });
 
     const rows = await query(
       `INSERT INTO scores (game_id, player_id, hole, strokes)

--- a/backend/utils/gameAccess.js
+++ b/backend/utils/gameAccess.js
@@ -1,0 +1,34 @@
+import { queryOne } from '../db/pg.js';
+
+/**
+ * Zugriffs-Entscheidung für ein Spiel (Phase-2-Sichtbarkeit).
+ *
+ * Öffentliche Spiele sind für alle zugänglich. Private Spiele nur für den
+ * Ersteller (`created_by`) oder einen registrierten Mitspieler
+ * (`account_players` ∩ `game_players`). `accountId` darf null sein (anonym).
+ *
+ * Rückgabe:
+ *   { exists, allowed, isOwner, visibility, name }
+ * `exists=false` → Spiel gibt es nicht (Aufrufer antwortet 404).
+ * `allowed=false` bei existierendem Spiel → privat und kein Zugriff (403).
+ */
+export async function getGameAccess(gameId, accountId) {
+  const row = await queryOne(
+    `SELECT g.id, g.name, g.visibility, g.created_by,
+            ($2::uuid IS NOT NULL AND EXISTS (
+              SELECT 1 FROM game_players gp
+              JOIN account_players ap ON ap.player_id = gp.player_id
+              WHERE gp.game_id = g.id AND ap.account_id = $2::uuid
+            )) AS is_participant
+       FROM games g
+      WHERE g.id = $1`,
+    [gameId, accountId ?? null],
+  );
+
+  if (!row) return { exists: false, allowed: false, isOwner: false };
+
+  const isOwner = accountId != null && row.created_by === accountId;
+  const allowed = row.visibility !== 'private' || isOwner || row.is_participant === true;
+
+  return { exists: true, allowed, isOwner, visibility: row.visibility, name: row.name };
+}

--- a/frontend/e2e/smoke/private-games.spec.ts
+++ b/frontend/e2e/smoke/private-games.spec.ts
@@ -51,6 +51,19 @@ test.describe('Private Spiele (Smoke)', () => {
     await expect(item.locator('.mine__badge')).toHaveText(/Privat/)
   })
 
+  test('die Teilen-Ansicht kommuniziert die Zugriffs-Einschränkung (Phase 2)', async ({ page, mockApi }) => {
+    void mockApi
+    await signIn(page)
+    await createPrivateGame(page, 'Teilen-Privat-Runde')
+
+    // Vom Loch-View in die Detail-Ansicht wechseln und Teilen öffnen.
+    const gameId = new URL(page.url()).pathname.split('/')[2]
+    await page.goto(`/games/${gameId}`)
+    await page.getByRole('button', { name: 'Spiel teilen' }).click()
+
+    await expect(page.locator('.share__notice')).toContainText('Nur du und angemeldete Mitspieler')
+  })
+
   test('anonym ist das private Spiel nicht in „Alle", öffentliche schon', async ({ page, mockApi }) => {
     void mockApi
     await signIn(page)

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -183,7 +183,7 @@
   "Share": {
     "Title": "Spiel teilen",
     "EditWarning": "Jeder mit diesem Link kann Scores eintragen.",
-    "EditWarningPrivate": "Dieses Spiel ist privat. Es ist nicht öffentlich gelistet — aber wer diesen Link hat, kann es öffnen und Scores eintragen.",
+    "EditWarningPrivate": "Dieses Spiel ist privat. Nur du und angemeldete Mitspieler können es öffnen und Scores eintragen.",
     "LinkLabel": "Spiel-Link",
     "Copy": "Link kopieren",
     "Copied": "Kopiert!",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -183,7 +183,7 @@
   "Share": {
     "Title": "Share game",
     "EditWarning": "Anyone with this link can enter scores.",
-    "EditWarningPrivate": "This game is private. It is not publicly listed — but anyone with this link can open it and enter scores.",
+    "EditWarningPrivate": "This game is private. Only you and signed-in players in this game can open it and enter scores.",
     "LinkLabel": "Game link",
     "Copy": "Copy link",
     "Copied": "Copied!",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -183,7 +183,7 @@
   "Share": {
     "Title": "Partager la partie",
     "EditWarning": "Toute personne disposant de ce lien peut saisir des scores.",
-    "EditWarningPrivate": "Cette partie est privée. Elle n’apparaît pas dans la liste publique — mais toute personne disposant de ce lien peut l’ouvrir et saisir des scores.",
+    "EditWarningPrivate": "Cette partie est privée. Seuls toi et les joueurs connectés de cette partie peuvent l’ouvrir et saisir des scores.",
     "LinkLabel": "Lien de la partie",
     "Copy": "Copier le lien",
     "Copied": "Copié !",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -183,7 +183,7 @@
   "Share": {
     "Title": "Spel delen",
     "EditWarning": "Iedereen met deze link kan scores invoeren.",
-    "EditWarningPrivate": "Dit spel is privé. Het staat niet in de openbare lijst — maar iedereen met deze link kan het openen en scores invoeren.",
+    "EditWarningPrivate": "Dit spel is privé. Alleen jij en ingelogde spelers in dit spel kunnen het openen en scores invoeren.",
     "LinkLabel": "Spellink",
     "Copy": "Link kopiëren",
     "Copied": "Gekopieerd!",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -49,9 +49,11 @@ axios.interceptors.response.use(
     const config = error.config
     if (!config) return Promise.reject(error)
 
-    // 4xx: no retry, show toast (except 401)
+    // 4xx: no retry, show toast (except 401/403). 403 ist ein erwartetes
+    // „kein Zugriff" (private Spiele) und wird von der jeweiligen View über
+    // ihren Fehlerzustand behandelt — kein Toast (sonst spammt das Polling).
     if (error.response?.status >= 400 && error.response?.status < 500) {
-      if (error.response.status !== 401) {
+      if (error.response.status !== 401 && error.response.status !== 403) {
         const { error: showError } = useToast()
         showError(`${t('Errors.RequestFailed')} (${error.response.status})`)
       }


### PR DESCRIPTION
Implementiert Phase 2 des PRD #115 — private Spiele sind jetzt nicht nur *ungelistet*, sondern beim **Direktzugriff zugriffsgeschützt**.

## Was drin ist

**Backend**
- Neuer Helper `getGameAccess(gameId, accountId)` → `public` | Ersteller | registrierter Mitspieler (`account_players` ∩ `game_players`).
- `GET /games/:id` und `/:id/players`: 404 wenn nicht vorhanden, **403** wenn privat & kein Zugriff, sonst 200.
- `GET`/`POST /scores` identisch abgesichert → **beendet bewusst das anonyme „Scoren per geteiltem Link" für private Spiele** (Phase-2-Semantik). Öffentliche Spiele bleiben unverändert per Direktlink zugänglich.

**Frontend**
- Axios-Interceptor schluckt **403** still (die jeweilige View behandelt es über ihren Fehlerzustand) — sonst würde das 4s-Score-Polling Toasts spammen.
- Privat-Teilen-Hinweis umformuliert: nicht mehr „wer den Link hat", sondern „nur du und angemeldete Mitspieler" (de/en/fr/nl).

**Tests**
- Backend-Route-Tests für Spiele + Scores: Fremd/anonym → 403, Ersteller/Teilnehmer → 200, öffentlich → 200.
- Playwright-Smoke für den umformulierten Teilen-Hinweis.

## Entscheidungen / Hinweise
- **403 vs. 404**: Das Issue #119 spezifiziert 403 für fremde private Spiele — so umgesetzt. (404 wäre privacy-freundlicher, weil es die Existenz nicht verrät; falls gewünscht, leicht umstellbar.)
- **Verhaltensänderung**: Ein privates Spiel kann jetzt nur noch von eingeloggten Teilnehmern gescort werden — ein gemeinsames, nicht eingeloggtes Scorekeeper-Gerät ist für private Spiele ausgeschlossen. Für öffentliche Spiele unverändert.

## Test-Status
Backend 84 ✓ · Frontend-Unit 137 ✓ · Lint + Type-Check ✓ · Smoke 92 ✓ (inkl. 4 Private-Spiele-Tests).

Closes #119. Refs #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
