### PR TITLE
Fix score loss on flaky connections and raise hole limit

### DIFF
--- a/backend/db/init/schema.sql
+++ b/backend/db/init/schema.sql
@@ -106,7 +106,7 @@ CREATE TABLE public.scores (
     hole integer NOT NULL,
     strokes integer NOT NULL,
     id bigint NOT NULL,
-    CONSTRAINT chk_hole CHECK ((hole >= 1 AND hole <= 18)),
+    CONSTRAINT chk_hole CHECK ((hole >= 1 AND hole <= 200)),
     CONSTRAINT chk_strokes CHECK ((strokes >= -3 AND strokes <= 20))
 );
 

--- a/backend/db/migrations/011_raise-hole-limit.sql
+++ b/backend/db/migrations/011_raise-hole-limit.sql
@@ -1,0 +1,20 @@
+-- Loch-Obergrenze von 18 auf 200 anheben.
+--
+-- Die 18 stammt aus der Schema-Härtung (002_harden-scores-schema) und war die
+-- Zahl aus dem klassischen Golf — nie eine fachliche Anforderung. Urban-Golf-
+-- Runden haben typischerweise 9, 12 oder auch deutlich mehr Bahnen, und das
+-- Limit hat solche Runden schlicht abgeschnitten (POST /scores gab 400).
+--
+-- 200 bleibt als reine Sanity-Grenze bestehen: sie fängt kaputte Loch-Nummern
+-- aus veralteten Links oder korrupten Navigationen ab, ohne reale Runden zu
+-- begrenzen. Die Grenze wird im Frontend und Backend aus dem gemeinsamen
+-- Contract gelesen (packages/contract → VALIDATION.HOLE_MAX) — beide Werte
+-- müssen zusammen geändert werden.
+--
+-- Rein erweiternd: keine bestehende Zeile verletzt die neue Bedingung.
+-- Idempotent: erneutes Ausführen ist folgenlos.
+ALTER TABLE public.scores
+  DROP CONSTRAINT IF EXISTS chk_hole;
+
+ALTER TABLE public.scores
+  ADD CONSTRAINT chk_hole CHECK (hole >= 1 AND hole <= 200);

--- a/backend/routes/scores.js
+++ b/backend/routes/scores.js
@@ -27,7 +27,12 @@ export default async function (fastify, _opts) {
     schema: schemas.postScore,
     config: {
       rateLimit: {
-        max: 60,
+        // Das Limit greift pro IP — eine Gruppe am selben Hotspot (oder mehrere
+        // Geräte an derselben Runde) teilt es sich. Mit 60/min reichten wenige
+        // Löcher zu sechst, um 429 zu kassieren; da 4xx nicht wiederholt wird,
+        // ging der Score dabei früher verloren. 300 lässt normales Scoring
+        // durch und bremst weiterhin echten Missbrauch.
+        max: 300,
         timeWindow: '1 minute',
       },
     },

--- a/frontend/public/CHANGELOG.md
+++ b/frontend/public/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ---
 
+## [Unreleased]
+### 🪲 Bugfixes
+- Scores gehen bei wackliger Verbindung nicht mehr verloren — bisher konnten
+  einzelne Löcher aus einer Runde verschwinden, wenn der Browser sich für online
+  hielt, der Request aber scheiterte (WLAN ohne Internet, Captive Portal,
+  schwaches Mobilnetz). Jede Eingabe landet jetzt zuerst in der Sync-Queue.
+- Offline erfasste Scores werden auch dann übertragen, wenn die App zwischendurch
+  geschlossen wurde (Flush beim Start statt nur beim Online-Wechsel)
+- Der letzte Score geht nicht mehr verloren, wenn direkt danach das Handy
+  gesperrt wird
+
+### ✨ Verbesserungen
+- Runden sind nicht mehr auf 18 Löcher begrenzt (neu bis 200) — Urban-Golf-Runden
+  folgen nicht dem klassischen 18-Loch-Schema
+- Rate-Limit für Score-Eingaben angehoben, damit grössere Gruppen im selben
+  Netz sich nicht gegenseitig ausbremsen
+
+> **Migration:** `011_raise-hole-limit.sql` hebt den `chk_hole`-Constraint an.
+> Wird beim Container-Start automatisch angewendet.
+
+---
+
 ## [3.0.0] – 2026-04-16
 ### 🎨 Greenway Design-System
 - Komplett neu designtes UI: mobile-first, Ranking-First Scorecard

--- a/frontend/src/components/games/GamesHoleView.vue
+++ b/frontend/src/components/games/GamesHoleView.vue
@@ -431,18 +431,27 @@ async function runSave(lockKey: string) {
   inFlight.add(lockKey)
   savingMap.value[playerId] = true
   try {
+    // Sobald ein Score erfasst ist, taucht das Loch in der geteilten
+    // holes-Liste auf — ein "weitergeblättertes" Loch OHNE Score erscheint
+    // weder in der Scorecard noch im Pill-Strip.
+    //
+    // Massgeblich ist die Erfassung, nicht die Server-Antwort: saveScore legt
+    // den Wert immer in der Sync-Queue ab und stellt ihn spätestens beim
+    // nächsten Retry zu. Früher hing das Loch an einem erfolgreichen Request —
+    // schlug der fehl, verschwand es spurlos aus der Runde.
+    if (Number.isInteger(h) && !holes.value.includes(h)) {
+      holes.value = [...holes.value, h].sort((a, b) => a - b)
+    }
     await saveScoreOffline({
       game_id: gameId.value,
       player_id: playerId,
       hole: h,
       strokes: Number(scores.value[playerId][h]),
     })
-    // Erst NACHDEM ein Score gespeichert ist, tauchen wir das Loch in der
-    // geteilten holes-Liste auf — so erscheint ein "weitergeblättertes" Loch
-    // OHNE eingegebenen Score weder in der Scorecard noch im Pill-Strip.
-    if (Number.isInteger(h) && !holes.value.includes(h)) {
-      holes.value = [...holes.value, h].sort((a, b) => a - b)
-    }
+  } catch (err) {
+    // saveScore wirft per Vertrag nicht — hier landet nur Unerwartetes. Ohne
+    // diesen Zweig würde es als Unhandled Rejection verpuffen.
+    console.error('Score-Save fehlgeschlagen:', err)
   } finally {
     inFlight.delete(lockKey)
     savingMap.value[playerId] = false
@@ -489,13 +498,25 @@ watch(() => hole.value, () => {
   requestAnimationFrame(() => scrollCurrentPillIntoView())
 })
 
+// Beim Backgrounding der PWA (Handy sperren direkt nach dem letzten Score)
+// läuft der 400-ms-Debounce nicht mehr ab — das OS friert die App vorher ein
+// und der Wert war weg. `hidden`/`pagehide` ist der letzte Moment, in dem wir
+// ihn noch in die Sync-Queue schreiben können.
+function flushOnHidden() {
+  if (document.visibilityState === 'hidden') flushPendingSaves()
+}
+
 onMounted(() => {
   requestAnimationFrame(() => scrollCurrentPillIntoView())
   window.addEventListener('keydown', onKeypadKey)
+  document.addEventListener('visibilitychange', flushOnHidden)
+  window.addEventListener('pagehide', flushPendingSaves)
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeypadKey)
+  document.removeEventListener('visibilitychange', flushOnHidden)
+  window.removeEventListener('pagehide', flushPendingSaves)
   // Nicht verworfene Eingaben beim Verlassen der View noch persistieren.
   flushPendingSaves()
 })

--- a/frontend/src/stores/__tests__/scoreSync.test.ts
+++ b/frontend/src/stores/__tests__/scoreSync.test.ts
@@ -82,6 +82,31 @@ describe('useScoreSyncStore', () => {
       expect(queueStore.queue).toHaveLength(1)
       expect(queueStore.queue[0]).toMatchObject({ game_id: 'g1234567890123', hole: 1, strokes: 3 })
     })
+
+    // Kernregression: `navigator.onLine` meldet auf dem Platz auch dann online,
+    // wenn der Request stirbt (Captive Portal, schwaches Netz, 429). Früher war
+    // der Score damit weder gespeichert noch gequeued — das Loch fehlte danach.
+    it('keeps the score queued when the request fails while online', async () => {
+      mockApiSave.mockRejectedValue(new Error('Network error'))
+      const store = scope.run(() => useScoreSyncStore())!
+
+      await expect(
+        store.saveScore({ game_id: 'g1234567890123', player_id: 'p1234567890123', hole: 7, strokes: 5 })
+      ).resolves.toBeUndefined()
+
+      expect(mockApiSave).toHaveBeenCalled()
+      expect(queueStore.queue).toHaveLength(1)
+      expect(queueStore.queue[0]).toMatchObject({ hole: 7, strokes: 5 })
+    })
+
+    it('does not toast on the per-tap path', async () => {
+      mockApiSave.mockResolvedValue({ id: 1, game_id: 'g1234567890123', player_id: 'p1234567890123', hole: 1, strokes: 3 })
+      const store = scope.run(() => useScoreSyncStore())!
+
+      await store.saveScore({ game_id: 'g1234567890123', player_id: 'p1234567890123', hole: 1, strokes: 3 })
+
+      expect(mockSuccess).not.toHaveBeenCalled()
+    })
   })
 
   describe('flushQueue', () => {
@@ -166,6 +191,20 @@ describe('useScoreSyncStore', () => {
 
       expect(mockSuccess).toHaveBeenCalledWith('Network.BackOnline', 3000)
       expect(mockApiSave).toHaveBeenCalled()
+      expect(queueStore.queue).toHaveLength(0)
+    })
+
+    // Der Watcher feuert nur bei einem Übergang. Wer offline erfasst und die
+    // PWA schliesst, startet sie später online neu — ohne Übergang blieb die
+    // Queue sonst dauerhaft liegen.
+    it('flushes a queue left over from a previous session on install', async () => {
+      queueStore.enqueue({ game_id: 'g1234567890123', player_id: 'p1234567890123', hole: 4, strokes: 2 })
+      mockApiSave.mockResolvedValue({ id: 1, game_id: 'g1234567890123', player_id: 'p1234567890123', hole: 4, strokes: 2 })
+
+      scope.run(() => useScoreSyncStore().installNetworkWatcher())
+      await new Promise(r => setTimeout(r, 50))
+
+      expect(mockApiSave).toHaveBeenCalledTimes(1)
       expect(queueStore.queue).toHaveLength(0)
     })
 

--- a/frontend/src/stores/scoreSync.ts
+++ b/frontend/src/stores/scoreSync.ts
@@ -6,26 +6,53 @@ import { useSyncQueueStore } from '@/stores/syncQueue'
 import { saveScore as apiSaveScore } from '@/services/api'
 import { useToast } from '@/composables/useToast'
 
+/** Wiederholversuch, solange Scores in der Queue liegen (Flush fehlgeschlagen). */
+const RETRY_INTERVAL_MS = 30_000
+
 export const useScoreSyncStore = defineStore('scoreSync', () => {
   const queue = useSyncQueueStore()
   const isOnline = useOnline()
   const { success, warning, error } = useToast()
   const { t } = useI18n()
 
+  /**
+   * Jeder Score geht IMMER zuerst in die Queue — auch online.
+   *
+   * Vorher entschied `navigator.onLine`, ob überhaupt gequeued wird. Auf dem
+   * Platz ist das unzuverlässig (WLAN ohne Internet, Captive Portal, schwaches
+   * Mobilnetz, 429 vom Rate-Limit): der Browser meldet „online", der Request
+   * stirbt trotzdem — und der Score war weder gespeichert noch gequeued. Das
+   * Loch fehlte anschliessend komplett, weil die holes-Liste aus den
+   * Server-Scores rekonstruiert wird.
+   *
+   * Wirft nie. Ein nicht zugestellter Score bleibt in der Queue und wird vom
+   * Retry-Loop, beim nächsten Online-Übergang oder bei Rückkehr aus dem
+   * Hintergrund erneut versucht.
+   */
   async function saveScore(payload: {
     game_id: string
     player_id: string
     hole: number
     strokes: number
   }): Promise<void> {
-    if (!isOnline.value) {
-      queue.enqueue(payload)
-      return
-    }
-    await apiSaveScore(payload)
+    queue.enqueue(payload)
+    if (!isOnline.value) return
+    // Still: der Einzel-Tap darf nicht bei jedem Strich eine Toast auslösen.
+    await flushQueue({ quiet: true })
   }
 
-  async function flushQueue(): Promise<void> {
+  // Flushes werden serialisiert. Ohne das könnte ein Queue-Flush parallel zum
+  // Direkt-Save desselben Feldes laufen und ein alter Wert den neueren
+  // überschreiben (Out-of-order-Write).
+  let chain: Promise<void> = Promise.resolve()
+
+  function flushQueue(opts: { quiet?: boolean } = {}): Promise<void> {
+    const run = () => runFlush(opts.quiet === true)
+    chain = chain.then(run, run)
+    return chain
+  }
+
+  async function runFlush(quiet: boolean): Promise<void> {
     if (!isOnline.value || queue.queue.length === 0) return
 
     const items = [...queue.queue]
@@ -43,10 +70,14 @@ export const useScoreSyncStore = defineStore('scoreSync', () => {
         queue.remove(item.id)
         successCount++
       } catch {
+        // Bleibt in der Queue — der nächste Versuch übernimmt.
         failCount++
       }
     }
 
+    // Ausstehende Scores meldet im stillen Pfad der Sync-Indikator über die
+    // Queue-Länge; Netzfehler toastet bereits der Axios-Interceptor.
+    if (quiet) return
     if (successCount > 0) {
       success(t('Sync.Synced', { n: successCount }), 3000)
     }
@@ -70,6 +101,28 @@ export const useScoreSyncStore = defineStore('scoreSync', () => {
         warning(t('Network.Offline'), 0)
       }
     })
+
+    // Beim Start einmal flushen: Der Watcher feuert nur bei einem ÜBERGANG. Wer
+    // offline erfasst und die PWA schliesst, startet sie später online neu —
+    // ohne Übergang bliebe die Queue sonst dauerhaft im localStorage liegen.
+    void flushQueue()
+
+    // Danach in Ruhe weiterversuchen. Deckt die Fälle ab, in denen
+    // `navigator.onLine` durchgehend true bleibt, die Zustellung aber scheitert
+    // (Captive Portal, 5xx-Fenster, Rate-Limit).
+    setInterval(() => {
+      if (queue.queue.length > 0) void flushQueue()
+    }, RETRY_INTERVAL_MS)
+
+    // Rückkehr aus dem Hintergrund ist der häufigste Moment, in dem wieder
+    // echtes Netz da ist, ohne dass `online` je gefeuert hätte.
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible' && queue.queue.length > 0) {
+          void flushQueue()
+        }
+      })
+    }
   }
 
   return { saveScore, flushQueue, installNetworkWatcher, queue: queue.queue, isOnline }

--- a/frontend/src/stores/syncQueue.ts
+++ b/frontend/src/stores/syncQueue.ts
@@ -11,7 +11,10 @@ export interface QueuedScore {
 }
 
 export const useSyncQueueStore = defineStore('syncQueue', () => {
-  const queue = useLocalStorage<QueuedScore[]>('ug-sync-queue', [])
+  // flush: 'sync' schreibt sofort in den localStorage statt erst im nächsten
+  // Microtask. Entscheidend beim Backgrounding: wer den letzten Score tippt und
+  // direkt das Handy sperrt, dessen Eintrag muss die eingefrorene PWA überleben.
+  const queue = useLocalStorage<QueuedScore[]>('ug-sync-queue', [], { flush: 'sync' })
 
   function enqueue(score: Omit<QueuedScore, 'id' | 'queuedAt'>) {
     // Deduplizierung: gleicher game+player+hole → neuesten Wert überschreiben
@@ -25,11 +28,15 @@ export const useSyncQueueStore = defineStore('syncQueue', () => {
       id: crypto.randomUUID(),
       queuedAt: Date.now(),
     }
+    // Neue Array-Referenz statt In-Place-Mutation — so greift der Persistenz-
+    // Watcher zuverlässig, auch beim Ersetzen eines bestehenden Eintrags.
+    const next = [...queue.value]
     if (idx >= 0) {
-      queue.value[idx] = entry
+      next[idx] = entry
     } else {
-      queue.value.push(entry)
+      next.push(entry)
     }
+    queue.value = next
   }
 
   function remove(id: string) {

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -2,7 +2,7 @@ export interface ValidationLimits {
   readonly STROKES_MIN: -3;
   readonly STROKES_MAX: 20;
   readonly HOLE_MIN: 1;
-  readonly HOLE_MAX: 18;
+  readonly HOLE_MAX: 200;
   readonly NAME_MAX_LENGTH: 100;
   readonly GAME_NAME_MAX_LENGTH: 100;
   readonly MESSAGE_MAX_LENGTH: 2000;

--- a/packages/contract/index.js
+++ b/packages/contract/index.js
@@ -7,7 +7,12 @@ export const VALIDATION = Object.freeze({
   STROKES_MIN: -3,
   STROKES_MAX: 20,
   HOLE_MIN: 1,
-  HOLE_MAX: 18,
+  // Urban-Golf-Runden folgen nicht dem klassischen 18-Loch-Schema — 9, 12 oder
+  // deutlich längere Stadtrunden sind üblich. Der Wert ist deshalb nur eine
+  // Sanity-Grenze gegen Müll-Daten (kaputte Links, /games/:id/99999), keine
+  // fachliche Limitierung. Wer sie erhöht, braucht zusätzlich eine Migration
+  // für chk_hole (siehe backend/db/migrations/011_raise-hole-limit.sql).
+  HOLE_MAX: 200,
   NAME_MAX_LENGTH: 100,
   GAME_NAME_MAX_LENGTH: 100,
   MESSAGE_MAX_LENGTH: 2000,


### PR DESCRIPTION
Behebt zwei gemeldete Punkte aus dem App-Feedback: gelegentlich übersprungene Löcher, und das 18-Loch-Limit.

## 1. Übersprungene Löcher

**Ursache:** `saveScore` hat nur gequeued, wenn `navigator.onLine === false` war — und der Aufrufer in `GamesHoleView` hatte kein `catch`. Auf dem Platz meldet der Browser aber regelmässig "online", während der Request stirbt (WLAN ohne Internet, Captive Portal, schwaches Mobilnetz, 429 vom Rate-Limit). Der Score war dann **weder gespeichert noch gequeued**, und die Rejection verpuffte als Unhandled Rejection.

Sichtbar wurde das erst später: der Wert stand im lokalen State, also sah der Erfasser ihn während der Runde. Da die `holes`-Liste aus den Server-Scores rekonstruiert wird und ein Loch erst *nach* erfolgreichem Save aufgenommen wurde, fehlte nach einem Reload das ganze Loch — nicht nur ein Score.

**Fix — jeder Score geht immer zuerst in die Queue, auch online:**

- `saveScore` wirft nicht mehr; nicht Zugestelltes bleibt in der Queue
- Flushes serialisiert → ein alter Queue-Eintrag kann keinen neueren Wert mehr überschreiben (Out-of-order-Write)
- Flush **beim App-Start**, bei Rückkehr aus dem Hintergrund, und 30s-Retry solange etwas aussteht. Bisher flushte nur der Online-Watcher — und der feuert nur bei einem *Übergang*. Wer offline erfasste und die PWA schloss, dessen Queue blieb dauerhaft im localStorage liegen.
- Debounce-Flush auf `pagehide`/`hidden`: Handy sperren direkt nach dem letzten Score verlor ihn bisher, weil der 400-ms-Timer nicht mehr ablief
- Queue schreibt synchron in den localStorage, damit sie eine eingefrorene PWA überlebt
- Ein Loch erscheint sobald der Score *erfasst* ist, nicht erst nach Server-Bestätigung
- Rate-Limit `POST /scores` 60 → 300/min. Es greift pro IP, eine Gruppe am selben Hotspot teilt es sich; 4xx wird nicht wiederholt, deshalb ging der Score bei 429 bisher verloren.

## 2. Loch-Limit 18 → 200

Die 18 stammt aus der Schema-Härtung in `002_harden-scores-schema` und war die Zahl aus dem klassischen Golf — nie eine fachliche Anforderung. Urban-Golf-Runden haben 9, 12 oder deutlich mehr Bahnen.

200 bleibt als reine Sanity-Grenze: sie fängt kaputte Loch-Nummern aus veralteten Links ab, die sonst als `hole=99999`-Kachel in der Scorecard landen. Gesetzt in Migration `011` und im geteilten Contract (`VALIDATION.HOLE_MAX`), aus dem Frontend und Backend lesen.

## Tests

- 140 Frontend-Unit ✅ · 77 Backend-Unit ✅ · ESLint ✅ · `vue-tsc` ✅
- Drei neue Tests in `scoreSync.test.ts`: fehlgeschlagener Online-Save bleibt in der Queue (die Kernregression), kein Toast im Einzel-Tap-Pfad, Flush einer Alt-Queue beim Start
- Smoke-E2E 89/90 — der rote `game-ownership`-Test schlägt **auch auf `main` ohne diese Änderungen** fehl (per Stash gegengeprüft), also vorbestehend und nicht Teil dieses PRs

## Reviewer-Notiz

`011_raise-hole-limit.sql` droppt `chk_hole` und setzt ihn neu. Rein erweiternd, keine bestehende Zeile verletzt die neue Bedingung, idempotent. Wird beim Container-Start automatisch angewendet (`docker-entrypoint.sh`).

Bewusst offen gelassen: der Sync-Indikator zeigt weiterhin nur die Queue-Länge global — ein Pending-Marker am einzelnen Score-Feld wäre ein eigener UI-Task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
