### PR TITLE
Move CI and container images off EOL Node 20 to Node 24 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,12 @@ updates:
       docker-base-images:
         patterns:
           - "*"
+    # Dependabot folgt beim node-Tag stumpf dem höchsten Major und kennt den
+    # LTS-Status nicht — so kam #135 mit einem Sprung auf das damalige Non-LTS
+    # node:26. Major-Wechsel machen wir bewusst: jeden Oktober, wenn der neue
+    # LTS-Zweig aufgeht (Node 26 wird 10/2026 LTS). Patches innerhalb von
+    # node:24-alpine kommen ohnehin über das floating Tag.
+    ignore:
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '24'
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}/urbangolf
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Backend Dockerfile
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 
 # Copy root package files and every workspace's package.json so npm can
@@ -13,7 +13,7 @@ COPY packages/contract/ ./packages/contract/
 # Install only backend production dependencies, plus the shared contract.
 RUN npm ci --workspace=backend --workspace=@urban-golf/contract --omit=dev
 
-FROM node:20-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Frontend Dockerfile
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 
 # Copy root package files and every workspace's package.json so npm can
@@ -14,7 +14,7 @@ COPY packages/contract/ ./packages/contract/
 # for the vite build).
 RUN npm ci --workspace=frontend --workspace=@urban-golf/contract
 
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 
 # Build arguments for environment variables


### PR DESCRIPTION
## Warum

**Node 20 (Iron) ist seit April 2026 EOL** — letztes Release war 20.20.2 am 2026-03-24, es gibt keine Security-Patches mehr. CI und beide Dockerfiles hingen noch darauf.

Gleichzeitig schlug Dependabot in #135 einen Sprung auf `node:26-alpine` vor. Geprüft gegen `nodejs.org/dist/index.json`:

| Major | Status | letztes Release |
|---|---|---|
| 26 | `lts=false` → **Current, kein LTS** | 2026-08-05 |
| **24** (Krypton) | **Active LTS** | 2026-08-03 |
| 22 (Jod) | LTS (Maintenance) | 2026-07-28 |
| 20 (Iron) | LTS, **EOL** | 2026-03-24 |

Dependabot folgt beim `node`-Tag stumpf dem höchsten Major und kennt den LTS-Status nicht. #135 hätte die Produktions-Runtime also von einem EOL-LTS auf ein **Non-LTS-Current** gehoben — und dabei `NODE_VERSION` in `ci.yml` nicht angefasst, weil das eine Env-Variable ist, die Dependabot nicht verwaltet. Ergebnis wäre CI auf 20 und Produktion auf 26 gewesen.

Dieser PR zieht stattdessen **alles gemeinsam auf Node 24 (Active LTS)**.

## Was

```
.github/workflows/ci.yml   NODE_VERSION 20 -> 24
backend/Dockerfile         node:20-alpine -> node:24-alpine  (deps, runner)
frontend/Dockerfile        node:20-alpine -> node:24-alpine  (deps, builder)
```

Damit laufen **Dev, CI und Produktion auf demselben Major** — lokal war ohnehin schon 24.x im Einsatz, das war bisher die dritte abweichende Runtime.

Zusätzlich in `dependabot.yml`: `ignore` für Major-Bumps des `node`-Images. LTS-Wechsel sind eine bewusste Oktober-Entscheidung (Node 26 wird 10/2026 LTS), Patches fliessen weiterhin über das floating `24-alpine`-Tag.

**#135 kann mit dem Merge geschlossen werden.**

## Tests

⚠️ **Die Dockerfile-Änderung deckt die PR-CI nicht ab** — `Deploy Backend` und `Deploy Frontend` sind bei PRs `SKIPPED`, die Images werden erst beim Push auf `main` gebaut. Ich habe deshalb lokal gebaut:

- `docker build -f backend/Dockerfile` ✅
- `docker build -f frontend/Dockerfile` ✅ (inkl. Vite-Build + PWA-Precache im builder-Stage)
- Runtime im Backend-Image verifiziert: **`node -v` → v24.19.0**
- Backend-Container startet, Entrypoint und Migrations-Skript laufen sauber an (bricht erwartungsgemäss ohne `DATABASE_URL` ab — keine Modul- oder Syntaxfehler)

Der Frontend-Final-Stage ist `nginx:alpine`, dort ist Node nur im Build-Stage relevant.

Die CI dieses PRs ist gleichzeitig der eigentliche Beweis für Lint, Type-Check, Unit und E2E auf Node 24.

## Reviewer-Notiz

Keine Code-, Schema- oder Dependency-Änderungen — reine Runtime-Version.

Der erste Push auf `main` nach dem Merge baut die Images neu auf Node 24. Da der Backend-Container Migrations im Entrypoint fährt, lohnt ein Blick in die Deploy-Logs, dass der erste Start durchläuft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
