### PR TITLE
Remove dead migrate:down scripts, record forward-only decision

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,6 @@
     "migrate:baseline": "node --env-file-if-exists=../.env --env-file-if-exists=./.env scripts/baseline-migrations.js",
     "migrate": "node --env-file-if-exists=../.env --env-file-if-exists=./.env ../node_modules/node-pg-migrate/bin/node-pg-migrate.js --migration-file-language sql -m db/migrations",
     "migrate:up": "npm run migrate:baseline && node --env-file-if-exists=../.env --env-file-if-exists=./.env ../node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migration-file-language sql -m db/migrations",
-    "migrate:down": "node --env-file-if-exists=../.env --env-file-if-exists=./.env ../node_modules/node-pg-migrate/bin/node-pg-migrate.js down --migration-file-language sql -m db/migrations",
     "migrate:create": "node --env-file-if-exists=../.env --env-file-if-exists=./.env ../node_modules/node-pg-migrate/bin/node-pg-migrate.js create --migration-file-language sql -m db/migrations"
   },
   "dependencies": {

--- a/docs/adr/0001-forward-only-migrations.md
+++ b/docs/adr/0001-forward-only-migrations.md
@@ -1,0 +1,64 @@
+# ADR-0001: Migrations sind vorwärts-only
+
+- **Status:** Angenommen
+- **Datum:** 2026-08-10
+
+## Kontext
+
+Das Repo führte ein `db:migrate:down` bzw. `migrate:down` als npm-Skript. Es hat
+nie funktioniert: keine der elf SQL-Migrations in `backend/db/migrations/`
+definiert einen Down-Abschnitt, also bricht node-pg-migrate sofort ab mit
+
+```
+Error: User has disabled down migration on file: 011_raise-hole-limit
+```
+
+Das Verhalten ist unabhängig von der Version — gegen eine echte Postgres-16-Instanz
+sowohl mit node-pg-migrate 8.0.4 als auch 9.0.0 reproduziert. Das Skript war also
+kein kaputtes Feature, sondern eines, das es nie gab.
+
+Damit stand die Frage: Down-Abschnitte nachrüsten oder Vorwärts-only festschreiben?
+
+## Entscheidung
+
+**Migrations laufen ausschliesslich vorwärts.** Die toten `migrate:down`-Skripte
+sind entfernt, statt sie mit Rollback-Logik zu füllen.
+
+## Begründung
+
+Der Ausschlag kam nicht aus Bequemlichkeit, sondern daher, dass mehrere der
+bestehenden Migrations technisch nicht umkehrbar sind:
+
+- **`009_reset-name-based-claims`** führt ein `DELETE FROM public.account_players`
+  aus — ein bewusster Cutover auf das kanonische Identitätsmodell. Gelöschte
+  Zuordnungen kann kein Down-Abschnitt wiederherstellen; die Information
+  existiert nach der Migration schlicht nicht mehr.
+
+- **`011_raise-hole-limit`** hebt `chk_hole` von 18 auf 200. Ein Down würde die
+  Bedingung wieder auf `<= 18` setzen und genau dann scheitern, wenn Runden mit
+  mehr als 18 Bahnen existieren — also genau dann, wenn die Migration ihren
+  Zweck erfüllt hat. Ein Rollback, der nur solange klappt, wie er nutzlos ist.
+
+- **`001_initial-schema`** liesse sich nur durch das Verwerfen des kompletten
+  Schemas umkehren. Das ist in Produktion keine Operation, die jemand ausführen
+  möchte.
+
+Ein Down-Pfad, der für ein Drittel der Migrations nur pro forma existiert, ist
+schlechter als gar keiner: er suggeriert eine Sicherheit, die im Ernstfall nicht
+trägt.
+
+## Konsequenzen
+
+- Ein fehlerhafter Schema-Stand wird durch eine **neue, korrigierende Migration**
+  behoben, nicht durch ein Zurückrollen. Die Historie bleibt dadurch linear und
+  entspricht dem, was in Produktion tatsächlich passiert ist.
+- Neue Migrations müssen entsprechend sorgfältig geprüft werden, bevor sie auf
+  `main` landen — der Deploy fährt sie im Entrypoint des Backend-Containers
+  automatisch hoch.
+- Für lokales Zurücksetzen gibt es weiterhin `npm run db:reset`: es verwirft das
+  Docker-Volume und baut die Datenbank neu auf. Das ist in Dev der schnellere und
+  ehrlichere Weg als ein Migration-Rollback.
+- `backend/scripts/baseline-migrations.js` bleibt unverändert. Es stampt die
+  Baseline 001/002 für Altbestände, in denen das Schema über
+  `backend/db/init/schema.sql` geladen wurde, und ist von dieser Entscheidung
+  nicht berührt.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "db:import": "node scripts/db-import.js",
     "db:reset": "docker-compose -f docker-compose.dev.yml down -v && docker-compose -f docker-compose.dev.yml up -d",
     "db:migrate": "npm run migrate:up --workspace=backend",
-    "db:migrate:down": "npm run migrate:down --workspace=backend",
     "test": "npm run test --workspaces --if-present",
     "test:frontend": "npm run test --workspace=frontend",
     "test:backend": "npm run test --workspace=backend",


### PR DESCRIPTION
## Problem

`npm run db:migrate:down` existierte als Skript, hat aber **nie funktioniert**. Keine der elf SQL-Migrations in [backend/db/migrations/](backend/db/migrations/) definiert einen Down-Abschnitt, also bricht node-pg-migrate sofort ab:

```
Error: User has disabled down migration on file: 011_raise-hole-limit
```

Gefunden beim Rollback-Test für den node-pg-migrate-9-Bump. Gegen eine echte Postgres-16-Instanz gegengeprüft: **identisches Verhalten auf 8.0.4 und 9.0.0** — es war also keine Regression des Majors, sondern ein Feature, das es nie gab.

## Entscheidung

Statt Down-Abschnitte nachzurüsten wird **Vorwärts-only** festgeschrieben. Die toten Skripte sind entfernt, die Begründung liegt als [ADR-0001](docs/adr/0001-forward-only-migrations.md) bei.

Ausschlaggebend war nicht Bequemlichkeit, sondern dass mehrere Migrations technisch nicht umkehrbar sind:

- **009** führt `DELETE FROM account_players` aus — ein bewusster Cutover aufs kanonische Identitätsmodell. Gelöschte Zuordnungen kann kein Down wiederherstellen.
- **011** hebt `chk_hole` von 18 auf 200. Ein Down würde `<= 18` wiederherstellen und **genau dann scheitern, wenn Runden mit mehr als 18 Bahnen existieren** — also genau dann, wenn die Migration etwas gebracht hat. Ein Rollback, der nur klappt, solange er nutzlos ist.
- **001** liesse sich nur durch Verwerfen des kompletten Schemas umkehren.

Ein Down-Pfad, der für ein Drittel der Migrations nur pro forma existiert, ist schlechter als keiner — er suggeriert eine Sicherheit, die im Ernstfall nicht trägt.

## Änderungen

- `db:migrate:down` aus [package.json](package.json) entfernt
- `migrate:down` aus [backend/package.json](backend/package.json) entfernt
- [docs/adr/0001-forward-only-migrations.md](docs/adr/0001-forward-only-migrations.md) neu

`migrate:up`, `migrate:baseline`, `migrate:create` und `backend/scripts/baseline-migrations.js` bleiben unverändert.

## Konsequenz für die Arbeitsweise

Ein fehlerhafter Schema-Stand wird künftig durch eine **neue, korrigierende Migration** behoben. Für lokales Zurücksetzen gibt es weiterhin `npm run db:reset`, das das Docker-Volume verwirft und die DB neu aufbaut — in Dev ohnehin der schnellere Weg.

Nebenbei etabliert dieser PR das Verzeichnis `docs/adr/`, das [CLAUDE.md](CLAUDE.md) und [docs/agents/domain.md](docs/agents/domain.md) bereits als Konvention führen, das es aber noch nicht gab.

## Tests

`lint` grün, 217 Unit-Tests grün. Reine Skript- und Doku-Ebene, kein Laufzeitcode berührt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
