### PR TITLE
Enable response compression, align async handlers with Fastify's contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Fastify 5 Backend, vollständig in Docker containerisierbar, Offline-fähig.
 ## Tech-Stack auf einen Blick
 
 - **Frontend**: Vue 3.4 + Vite 8 + TypeScript + Tailwind v4 + Pinia 3 + Vue-Router 5 + vue-i18n 11 + vite-plugin-pwa 1
-- **Backend**: Fastify 5 + pg (nativer PostgreSQL-Client)
+- **Backend**: Fastify 5 + pg (nativer PostgreSQL-Client) + @fastify/compress
 - **DB**: PostgreSQL 16 (Alpine) — Schema in [backend/db/init/schema.sql](backend/db/init/schema.sql)
 - **Tests**: Vitest (Unit) + Playwright Smoke-Suite mit Mock-API. Backend-Contract-Tests geplant — siehe [.claude/plans/backend-contract-tests.md](.claude/plans/backend-contract-tests.md).
 - **Infra**: Docker + Nginx (statische Auslieferung Frontend) + Traefik-ready, GitHub Actions CI/CD
@@ -47,6 +47,7 @@ npm run test:all       # lint + type-check + unit + smoke-e2e
 - **Kein Glass-Morphism** mehr (wurde durch Elevation ersetzt). Historische Klassen wie `glass-card`, `button-primary`, `input-field` existieren NICHT mehr — verwende die neuen Primitive in [frontend/src/components/ui/](frontend/src/components/ui/).
 - **ESLint + vue-tsc** müssen clean sein vor Commit. `npm run lint:fix` löst die meisten Style-Issues.
 - **Kommentare**: nur wo das *Warum* nicht offensichtlich ist. Keine What-Kommentare.
+- **Fastify-Handler müssen ihr Ergebnis zurückgeben** — `return reply.send(x)` oder `return wert`, nie nur `reply.send(x)`. Ein implizites `undefined` bedeutet für Fastify „die Antwort ist `undefined`" und liefert mit aktiver Kompression einen **leeren Body ohne Fehlermeldung**. Abgesichert durch [backend/routes/__tests__/compression.test.js](backend/routes/__tests__/compression.test.js).
 
 ## Skills
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -24,37 +24,52 @@ npm run dev                                                   # http://localhost
 | DB | PostgreSQL 16 via `pg` (nativer Client, kein ORM) |
 | Migrations | node-pg-migrate 9 (SQL-Files, vorwärts-only) |
 | Security | @fastify/helmet, @fastify/cors, @fastify/rate-limit |
-| Compression | keine — API-Antworten gehen unkomprimiert raus (siehe unten) |
+| Compression | @fastify/compress 9 (brotli + gzip, ab 1 KB — siehe unten) |
 | Mail | nodemailer (Brevo/SMTP für Feedback) |
 | Tests | Vitest 4 |
 | Lint | ESLint 10 |
 
 ### Zur Kompression
 
-Die Tabelle führte hier lange `@fastify/compress` — das Paket war zwar als
-Abhängigkeit deklariert, wurde aber nie in `app.js` registriert. API-Antworten
-waren also durchgehend unkomprimiert, entgegen der Doku.
+`@fastify/compress` ist in `app.js` global registriert und komprimiert
+API-Antworten ab 1 KB mit brotli oder gzip, je nach `Accept-Encoding`. Der
+Schwellwert entspricht dem `gzip_min_length` in `frontend/nginx.conf`, Brotli
+läuft auf Qualität 4 — für dynamische Antworten der sinnvolle Kompromiss.
 
-Nachträglich zu registrieren scheitert an einem Zusammenspiel von
-`@fastify/compress` und dem Handler-Stil dieser Codebasis: Ruft ein
-async-Handler `reply.send(x)` auf und gibt danach implizit `undefined` zurück
-— das Muster in allen Dateien unter `routes/` — startet Fastify einen zweiten
-`onSend`-Zyklus, dessen leerer Payload die bereits komprimierte Antwort
-überschreibt. Ergebnis: `content-length: 0` und ein leerer Body.
+Kompression gehört ins Backend, weil sie sonst nirgends passiert: In Produktion
+routet Traefik `/api` direkt aufs Backend, nginx sieht die API-Antworten also
+nie. Im Compose-Pfad liefe es zwar durch nginx, dessen `gzip` greift aber ohne
+`gzip_proxied` nicht für Upstream-Antworten.
 
-```js
-async (req, reply) => reply.send(big)      // 8981 B, korrekt
-async (req, reply) => { reply.send(big); } // 0 B, leerer Body
-```
+> **Wichtig für neue Routen:** Jeder async-Handler muss sein Ergebnis
+> zurückgeben — `return reply.send(x)` oder `return wert`.
+>
+> ```js
+> async (req, reply) => { return reply.send(data) }  // korrekt
+> async (req, reply) => { reply.send(data) }         // liefert einen leeren Body
+> ```
+>
+> Gibt der Handler implizit `undefined` zurück, ist das für Fastify die
+> Aussage „die Antwort ist `undefined`". Es folgt ein zweiter `onSend`-Zyklus,
+> dessen leerer Payload die bereits komprimierte Antwort überschreibt —
+> Resultat ist `content-length: 0` und ein leerer Body, ohne Fehlermeldung.
+>
+> Das ist kein Bug im Plugin, sondern Fastifys Promise-Semantik seit v4
+> ([fastify-compress#237](https://github.com/fastify/fastify-compress/issues/237)).
+> Ohne aktive Kompression fällt es nur nicht auf, weil Fastifys
+> „bereits gesendet"-Guard den zweiten Zyklus abfängt.
 
-Reproduziert in @fastify/compress 8.3.1 und 9.2.0, unter Windows wie im
-`node:24-alpine`-Container. Die Abhängigkeit ist deshalb entfernt statt
-verdrahtet.
+Gemessen an echten Antworten (Postgres 16, 60 Runden à 6 Spieler × 18 Löcher):
 
-Statische Frontend-Assets sind davon unberührt: die komprimiert
+| Endpunkt | identity | gzip | brotli |
+| --- | --- | --- | --- |
+| `GET /api/scores?game_id=…` | 13.663 B | 934 B (−93 %) | 862 B (−94 %) |
+| `GET /api/players` | 10.939 B | 1.043 B (−90 %) | 638 B (−94 %) |
+| `GET /api/games/summary` | 6.579 B | 737 B (−89 %) | 639 B (−90 %) |
+
+Statische Frontend-Assets laufen weiterhin einen eigenen Weg: die komprimiert
 `vite-plugin-compression2` beim Build vor, ausgeliefert via `gzip_static` in
-`frontend/nginx.conf`. Wer API-Antworten komprimieren will, setzt das am
-sinnvollsten im vorgelagerten Traefik auf — dort ohne diesen Fallstrick.
+`frontend/nginx.conf`.
 
 ## Projektstruktur
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -8,6 +8,7 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.join(__dirname, '..', '.env') });
 
 import Fastify from 'fastify';
+import fastifyCompress from '@fastify/compress';
 import fastifyHelmet from '@fastify/helmet';
 import fastifyRateLimit from '@fastify/rate-limit';
 import fastifyCookie from '@fastify/cookie';
@@ -89,6 +90,22 @@ await fastify.register(fastifyRateLimit, {
   skipOnError: true,
 });
 
+// Kompression passt sonst nirgends hin: In Produktion routet Traefik /api direkt
+// aufs Backend, nginx sieht die API-Antworten also nie. Im Compose-Pfad ginge es
+// zwar durch nginx, dessen `gzip` greift aber ohne `gzip_proxied` nicht für
+// Upstream-Antworten.
+//
+// Voraussetzung dafür ist, dass jeder async-Handler sein Ergebnis zurückgibt
+// (`return reply.send(x)`). Gibt er stattdessen implizit `undefined` zurück,
+// fährt Fastify einen zweiten onSend-Zyklus, dessen leerer Payload die
+// komprimierte Antwort überschreibt — Resultat ist `content-length: 0` und ein
+// leerer Body. Das ist kein Bug, sondern Fastifys Promise-Semantik seit v4,
+// siehe fastify/fastify-compress#237. Ohne Kompression fällt es nur nicht auf.
+//
+// Defaults bewusst nicht überschrieben: threshold 1024 entspricht dem
+// `gzip_min_length` in frontend/nginx.conf, Brotli läuft auf Qualität 4.
+await fastify.register(fastifyCompress);
+
 fastify.register(scoreRoutes, { prefix: '/api/scores' });
 fastify.register(gameRoutes, { prefix: '/api/games' });
 fastify.register(playerRoutes, { prefix: '/api/players' });
@@ -96,7 +113,7 @@ fastify.register(feedbackRoutes, { prefix: '/api/feedback' });
 fastify.register(authRoutes, { prefix: '/api/auth' });
 
 fastify.get('/', async (req, reply) => {
-  reply.send({ status: 'ok', service: 'Urban Golf API' });
+  return reply.send({ status: 'ok', service: 'Urban Golf API' });
 });
 
 const PORT = process.env.PORT || 3000;

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "migrate:create": "node --env-file-if-exists=../.env --env-file-if-exists=./.env ../node_modules/node-pg-migrate/bin/node-pg-migrate.js create --migration-file-language sql -m db/migrations"
   },
   "dependencies": {
+    "@fastify/compress": "^9.2.0",
     "@fastify/cookie": "^11.1.2",
     "@fastify/cors": "^11.3.0",
     "@fastify/helmet": "^13.1.0",

--- a/backend/routes/__tests__/compression.test.js
+++ b/backend/routes/__tests__/compression.test.js
@@ -1,0 +1,102 @@
+// Regressionsschutz für einen stillen Fehlermodus: Mit registriertem
+// @fastify/compress liefert ein async-Handler, der `reply.send(x)` aufruft und
+// danach implizit `undefined` zurückgibt, eine Antwort mit gesetztem
+// `content-encoding`, aber leerem Body (`content-length: 0`). Fastify wertet
+// das `undefined` als Ergebnis und fährt einen zweiten onSend-Zyklus, dessen
+// leerer Payload die komprimierte Antwort überschreibt — ohne Fehlermeldung,
+// ohne Log-Eintrag. Siehe fastify/fastify-compress#237.
+//
+// Der Test hält deshalb zwei Dinge fest: dass Kompression überhaupt greift,
+// und dass die komprimierten Bytes den unkomprimierten entsprechen.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Fastify from 'fastify'
+import compress from '@fastify/compress'
+import { gunzipSync, brotliDecompressSync } from 'node:zlib'
+
+import { pgMock } from './_pgMock.js'
+
+vi.mock('../../db/pg.js', () => pgMock(vi))
+
+import { getClient } from '../../db/pg.js'
+import playerRoutes from '../players.js'
+import { handleError } from '../../utils/errorHandler.js'
+
+// Über dem 1-KB-Schwellwert von @fastify/compress, sonst wird nicht komprimiert.
+const MANY_PLAYERS = Array.from({ length: 200 }, (_, i) => ({
+  id: `player${String(i).padStart(7, '0')}`,
+  name: `Testspieler Nummer ${i}`,
+}))
+
+async function buildApp() {
+  const app = Fastify({ logger: false })
+  app.setErrorHandler(handleError)
+  await app.register(compress)
+  app.register(playerRoutes, { prefix: '/' })
+  return app
+}
+
+describe('Response-Kompression', () => {
+  let app
+
+  beforeEach(async () => {
+    app = await buildApp()
+    getClient.mockReset()
+    getClient.mockResolvedValue({
+      query: vi.fn(() => ({ rows: MANY_PLAYERS, rowCount: MANY_PLAYERS.length })),
+      release: vi.fn(),
+    })
+  })
+
+  afterEach(() => app.close())
+
+  it('komprimiert grosse Antworten mit gzip und liefert einen nicht-leeren Body', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/',
+      headers: { 'accept-encoding': 'gzip' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-encoding']).toBe('gzip')
+    // Der eigentliche Regressionsschutz — hier stand früher 0.
+    expect(res.rawPayload.length).toBeGreaterThan(0)
+    expect(JSON.parse(gunzipSync(res.rawPayload).toString('utf8'))).toHaveLength(MANY_PLAYERS.length)
+  })
+
+  it('komprimiert mit brotli, wenn der Client es anbietet', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/',
+      headers: { 'accept-encoding': 'br' },
+    })
+
+    expect(res.headers['content-encoding']).toBe('br')
+    expect(res.rawPayload.length).toBeGreaterThan(0)
+    expect(JSON.parse(brotliDecompressSync(res.rawPayload).toString('utf8'))).toHaveLength(MANY_PLAYERS.length)
+  })
+
+  it('liefert byte-identische Daten wie die unkomprimierte Antwort', async () => {
+    const plain = await app.inject({ method: 'GET', url: '/', headers: { 'accept-encoding': 'identity' } })
+    const gzipped = await app.inject({ method: 'GET', url: '/', headers: { 'accept-encoding': 'gzip' } })
+
+    expect(plain.headers['content-encoding']).toBeUndefined()
+    expect(gunzipSync(gzipped.rawPayload).equals(plain.rawPayload)).toBe(true)
+    expect(gzipped.rawPayload.length).toBeLessThan(plain.rawPayload.length)
+  })
+
+  it('lässt Antworten unter dem Schwellwert unkomprimiert', async () => {
+    getClient.mockResolvedValue({
+      query: vi.fn(() => ({ rows: [{ id: 'player0000001', name: 'Alice' }], rowCount: 1 })),
+      release: vi.fn(),
+    })
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/',
+      headers: { 'accept-encoding': 'gzip' },
+    })
+
+    expect(res.headers['content-encoding']).toBeUndefined()
+    expect(JSON.parse(res.payload)).toHaveLength(1)
+  })
+})

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -327,7 +327,7 @@ export default async function (fastify, _opts) {
       const wins = played.filter((r) => Number(r.my_total) === Number(r.best_total)).length;
 
       const round2 = (n) => Math.round(n * 100) / 100;
-      reply.send({
+      return reply.send({
         rounds,
         overallAvg: totalHoles > 0 ? round2(totalStrokes / totalHoles) : null,
         bestRoundAvg: rounds ? round2(Math.min(...roundAvgs)) : null,

--- a/backend/routes/feedback.js
+++ b/backend/routes/feedback.js
@@ -38,6 +38,6 @@ export default async function (fastify, _opts) {
       }
     }
 
-    reply.send({ success: true });
+    return reply.send({ success: true });
   });
 }

--- a/backend/routes/games.js
+++ b/backend/routes/games.js
@@ -81,10 +81,10 @@ export default async function (fastify, _opts) {
         return gameResult.rows[0];
       });
 
-      reply.send({ ...game, status: 'upserted' });
+      return reply.send({ ...game, status: 'upserted' });
     } catch (err) {
       fastify.log.error({ id, players, error: err.message }, 'Failed to upsert game with players');
-      reply.code(500).send({ error: 'Database error' });
+      return reply.code(500).send({ error: 'Database error' });
     }
   });
 
@@ -136,13 +136,13 @@ export default async function (fastify, _opts) {
         query(countQuery, valuesCount),
       ]);
 
-      reply.send({
+      return reply.send({
         games,
         total: parseInt(countRows[0].count),
       });
     } catch (err) {
       fastify.log.error(err);
-      reply.code(500).send({ error: 'Database error' });
+      return reply.code(500).send({ error: 'Database error' });
     }
   });
 
@@ -161,7 +161,7 @@ export default async function (fastify, _opts) {
     const me = account?.id ?? null;
     const game = await queryOne(`SELECT id, name, visibility, created_by FROM games WHERE id = $1`, [gameId]);
     if (!game) return reply.code(404).send({ error: 'Not found' });
-    reply.send({
+    return reply.send({
       id: game.id,
       name: game.name,
       visibility: game.visibility,
@@ -185,7 +185,7 @@ export default async function (fastify, _opts) {
        WHERE gp.game_id = $1`,
       [gameId]
     );
-    reply.send(rows);
+    return reply.send(rows);
   });
 
   // Zusammenfassung with total count for pagination
@@ -269,13 +269,13 @@ export default async function (fastify, _opts) {
         query(countQuery, countValues),
       ]);
 
-      reply.send({
+      return reply.send({
         games,
         total: parseInt(countRows[0].count),
       });
     } catch (err) {
       fastify.log.error(err);
-      reply.code(500).send({ error: 'Database error' });
+      return reply.code(500).send({ error: 'Database error' });
     }
   });
 }

--- a/backend/routes/players.js
+++ b/backend/routes/players.js
@@ -21,17 +21,17 @@ export default async function (fastify, _opts) {
          ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name`,
         [id, name]
       );
-      reply.code(200).send({ id, name, status: 'upserted' });
+      return reply.code(200).send({ id, name, status: 'upserted' });
     } catch (err) {
       fastify.log.error(err);
-      reply.code(500).send({ error: 'Database error' });
+      return reply.code(500).send({ error: 'Database error' });
     }
   });
 
   // Alle Spieler abrufen
   fastify.get('/', async (_req, reply) => {
     const rows = await query('SELECT * FROM players ORDER BY name');
-    reply.send(rows);
+    return reply.send(rows);
   });
 
   // Registrierte Spieler suchen (Konten mit kanonischer Identität, d. h.
@@ -52,10 +52,10 @@ export default async function (fastify, _opts) {
          LIMIT 10`,
         [`%${q}%`],
       );
-      reply.send({ players: rows });
+      return reply.send({ players: rows });
     } catch (err) {
       fastify.log.error(err);
-      reply.code(500).send({ error: 'Database error' });
+      return reply.code(500).send({ error: 'Database error' });
     }
   });
 }

--- a/backend/routes/scores.js
+++ b/backend/routes/scores.js
@@ -20,7 +20,7 @@ export default async function (fastify, _opts) {
        ORDER BY s.hole ASC, p.name ASC`,
       [gameId]
     );
-    reply.send(rows);
+    return reply.send(rows);
   });
 
   fastify.post('/', {
@@ -47,6 +47,6 @@ export default async function (fastify, _opts) {
        RETURNING id`,
       [game_id, player_id, hole, strokes]
     );
-    reply.code(200).send({ id: rows[0].id, game_id, player_id, hole, strokes });
+    return reply.code(200).send({ id: rows[0].id, game_id, player_id, hole, strokes });
   });
 }

--- a/backend/utils/errorHandler.js
+++ b/backend/utils/errorHandler.js
@@ -16,7 +16,7 @@ export function handleError(error, request, reply) {
   }
   request.log.error(error);
   const statusCode = error.statusCode || 500;
-  reply.code(statusCode).send({
+  return reply.code(statusCode).send({
     error: statusCode >= 500 ? 'Internal server error' : error.message,
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "name": "urban-golf-backend",
       "version": "3.0.0",
       "dependencies": {
+        "@fastify/compress": "^9.2.0",
         "@fastify/cookie": "^11.1.2",
         "@fastify/cors": "^11.3.0",
         "@fastify/helmet": "^13.1.0",
@@ -1936,6 +1937,22 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-2.1.0.tgz",
+      "integrity": "sha512-F3EVbzWt+xcnVaOHmWyIlpuFtbxOln7HDZQsh09MtMmMm/CipMayNt8hnIL8VQi54u2ZociDbf+iluGYkf7B1A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
@@ -1979,6 +1996,29 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/@fastify/compress": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/compress/-/compress-9.2.0.tgz",
+      "integrity": "sha512-35VL33PIEt/UbD/ZMlRNaICd2BQz0IaG7en74Dv7tI+MHIQkedibS1+9JfekWH4I1g+Y8RbbZD4Zsk9h4XTItg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "fastify-plugin": "^6.0.0",
+        "mime-db": "^1.52.0",
+        "minipass": "^7.0.4",
+        "readable-stream": "^4.5.2"
+      }
+    },
     "node_modules/@fastify/cookie": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-11.1.2.tgz",
@@ -2012,22 +2052,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/@fastify/cookie/node_modules/fastify-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
-      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@fastify/cors": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.3.0.tgz",
@@ -2047,22 +2071,6 @@
         "fastify-plugin": "^6.0.0",
         "toad-cache": "^3.7.0"
       }
-    },
-    "node_modules/@fastify/cors/node_modules/fastify-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
-      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
@@ -2135,22 +2143,6 @@
         "helmet": "^8.0.0"
       }
     },
-    "node_modules/@fastify/helmet/node_modules/fastify-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
-      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
@@ -2211,22 +2203,6 @@
         "ip-address": "^10.2.0",
         "toad-cache": "^3.7.0"
       }
-    },
-    "node_modules/@fastify/rate-limit/node_modules/fastify-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
-      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@heroicons/vue": {
       "version": "2.2.0",
@@ -4593,6 +4569,18 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -4949,6 +4937,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.32",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
@@ -5021,6 +5029,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -6130,6 +6162,24 @@
         "url": "https://github.com/bgub/eta?sponsor=1"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -6275,6 +6325,22 @@
         "semver": "^7.6.0",
         "toad-cache": "^3.7.0"
       }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fastify/node_modules/ajv": {
       "version": "8.20.0",
@@ -7069,6 +7135,26 @@
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -8183,6 +8269,15 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
@@ -9036,6 +9131,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -9274,6 +9378,22 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/readdirp": {
@@ -9568,6 +9688,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -10004,6 +10144,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {


### PR DESCRIPTION
## Warum

API-Antworten gingen bisher **immer unkomprimiert** raus. `@fastify/compress` war deklariert und dokumentiert, aber nie registriert — und #145 hat es entfernt, nachdem die Registrierung leere Bodies produzierte.

Die Recherche im Upstream-Tracker hat das aufgeklärt: **es ist kein Plugin-Defekt.** [fastify-compress#237](https://github.com/fastify/fastify-compress/issues/237) beantwortet das seit 2022, von mcollina:

> *"We changed the default behavior in V4, promoting a good promise hygiene. Your promise returns `undefined`, so that's what you get."*

Ein async-Handler, der `reply.send(x)` aufruft und danach implizit `undefined` zurückgibt, sagt Fastify: die Antwort ist `undefined`. Es folgt ein zweiter `onSend`-Zyklus, dessen leerer Payload die komprimierte Antwort überschreibt → `content-length: 0`. Ohne Kompression verdeckt Fastifys „bereits gesendet"-Guard das, deshalb ist es nie aufgefallen.

Also werden die Handler korrigiert, nicht das Plugin verworfen.

## Was

**Handler-Vertrag hergestellt** — 17 `send`-Aufrufe in den fünf Route-Modulen geben ihr Ergebnis jetzt zurück, dazu [utils/errorHandler.js](backend/utils/errorHandler.js) (Fallthrough-Zweig, symmetrisch zum bereits korrekten Validierungszweig) und die Root-Route in [app.js](backend/app.js). [utils/auth.js](backend/utils/auth.js) war bereits korrekt — dessen preHandler macht `return reply`.

**`@fastify/compress` 9 global registriert**, Defaults bewusst unverändert: Schwellwert 1 KB entspricht `gzip_min_length` in [frontend/nginx.conf](frontend/nginx.conf), Brotli auf Qualität 4.

Kompression gehört ins Backend, weil sie sonst nirgends stattfindet: Traefik routet `/api` in Produktion direkt aufs Backend, und nginx' `gzip` deckt ohne `gzip_proxied` keine Upstream-Antworten ab.

## Messung

Gegen Postgres 16 mit 60 Runden à 6 Spielern × 18 Löchern — **lokal und im `node:24-alpine`-Container mit identischem Ergebnis**:

| Endpunkt | identity | gzip | brotli |
| --- | --- | --- | --- |
| `GET /api/scores?game_id=…` | 13.663 B | **934 B** (−93 %) | **862 B** (−94 %) |
| `GET /api/players` | 10.939 B | 1.043 B (−90 %) | 638 B (−94 %) |
| `GET /api/games/summary` | 6.579 B | 737 B (−89 %) | 639 B (−90 %) |

`/api/scores` ist der Endpunkt, den die App beim Scoring am häufigsten zieht — dort wirkt es am stärksten.

Geprüft wurden **alle** Endpunkte auf nicht-leeren Body, Fehlerpfade (404, Validierungsfehler, 401) eingeschlossen. Dekomprimierte Ausgabe ist byte-identisch zur unkomprimierten und parst als valides JSON. Antworten unter 1 KB bleiben korrekterweise unkomprimiert.

## Regressionsschutz

Der Fehlermodus ist **still** — keine Exception, kein Log-Eintrag, nur ein leerer Body. Ein Review fängt das nicht ab, deshalb [compression.test.js](backend/routes/__tests__/compression.test.js) mit vier Fällen: gzip, brotli, Byte-Identität und Schwellwert.

Dass der Test Zähne hat, habe ich verifiziert: ein einzelner Handler zurück auf `reply.send(x)` färbt drei der vier Fälle rot mit `AssertionError: expected 0 to be greater than 0`.

Zusätzlich eine Konventionszeile in [CLAUDE.md](CLAUDE.md), damit künftige Routen den Vertrag von vornherein einhalten.

## Doku korrigiert

Der Abschnitt in [backend/README.md](backend/README.md), den ich in #145 geschrieben hatte, stellte das als unlösbares „Zusammenspiel" dar. Das war falsch. Er beschreibt jetzt den aktiven Zustand, die Messwerte und — als hervorgehobener Hinweis — den Handler-Vertrag für neue Routen. [CLAUDE.md](CLAUDE.md) führt `@fastify/compress` wieder im Stack.

## Tests

`lint`, `type-check`, **221 Unit-Tests** (140 Frontend / 81 Backend, +4 neu), 90 E2E-Smoke — alles grün.

## Reviewer-Notiz

Erste Verhaltensänderung an Produktions-Antworten in dieser Serie. Clients handeln Kompression über `Accept-Encoding` aus; axios im Frontend dekomprimiert transparent, ebenso jeder Browser. Nach dem Merge lohnt ein Blick auf eine echte API-Antwort, ob `content-encoding` gesetzt ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
