### PR TITLE
Fix Docker builds breaking on non-hoisted workspace dependencies

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,13 @@ COPY frontend/package.json ./frontend/
 COPY packages/contract/ ./packages/contract/
 
 # Install only backend production dependencies, plus the shared contract.
-RUN npm ci --workspace=backend --workspace=@urban-golf/contract --omit=dev
+#
+# mkdir: npm hebt Workspace-Abhängigkeiten nur so weit ins Root-node_modules,
+# wie es kollisionsfrei geht — bei einem Versionskonflikt landen sie stattdessen
+# unter backend/node_modules. Das Verzeichnis muss deshalb existieren, damit der
+# COPY im runner-Stage nicht davon abhängt, wie npm gerade auflöst.
+RUN npm ci --workspace=backend --workspace=@urban-golf/contract --omit=dev \
+ && mkdir -p /app/backend/node_modules
 
 FROM node:24-alpine AS runner
 WORKDIR /app
@@ -19,9 +25,13 @@ ENV NODE_ENV=production
 
 RUN addgroup -g 1001 -S nodejs && adduser -S nodejs -u 1001
 
-# Copy hoisted node_modules + packages/ from workspace install so the
-# symlinked @urban-golf/contract resolves at runtime.
+# Copy node_modules + packages/ from workspace install so the symlinked
+# @urban-golf/contract resolves at runtime.
 COPY --from=deps /app/node_modules ./node_modules
+# Die nicht gehoisteten Pakete darüberlegen. Der Source liegt hier flach unter
+# /app/, es gibt also nur eine Auflösungsebene — und genau die muss der Sicht des
+# backend-Workspace entsprechen, wo Genestetes das Gehoistete überschattet.
+COPY --from=deps /app/backend/node_modules ./node_modules
 COPY --from=deps /app/packages ./packages
 
 # Copy backend source code (flat layout: backend/ contents → /app/)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,13 @@ COPY packages/contract/ ./packages/contract/
 
 # Install frontend + the shared contract workspace (devDependencies included
 # for the vite build).
-RUN npm ci --workspace=frontend --workspace=@urban-golf/contract
+#
+# mkdir: npm hebt Workspace-Abhängigkeiten nur so weit ins Root-node_modules,
+# wie es kollisionsfrei geht — bei einem Versionskonflikt landen sie stattdessen
+# unter frontend/node_modules. Das Verzeichnis muss deshalb existieren, damit
+# der COPY im builder-Stage nicht davon abhängt, wie npm gerade auflöst.
+RUN npm ci --workspace=frontend --workspace=@urban-golf/contract \
+ && mkdir -p /app/frontend/node_modules
 
 FROM node:24-alpine AS builder
 WORKDIR /app
@@ -24,6 +30,10 @@ ENV VITE_API_BASEURL=$VITE_API_BASEURL
 # Copy node_modules + packages/ from workspace install so the symlinked
 # @urban-golf/contract resolves at build time.
 COPY --from=deps /app/node_modules ./node_modules
+# Die nicht gehoisteten Pakete darüberlegen. Der Source liegt hier flach unter
+# /app/, es gibt also nur eine Auflösungsebene — und genau die muss der Sicht des
+# frontend-Workspace entsprechen, wo Genestetes das Gehoistete überschattet.
+COPY --from=deps /app/frontend/node_modules ./node_modules
 COPY --from=deps /app/packages ./packages
 
 # Copy frontend source code (flat layout: frontend/ contents → /app/)


### PR DESCRIPTION
## Problem

Das Frontend-Image lässt sich seit dem Merge von #146 **nicht mehr bauen**. `main` ist damit aktuell kaputt — die Tests laufen grün durch, aber `Deploy Frontend` bricht ab ([Run 31401329534](https://github.com/st-albani/sc.urban-golf.ch/actions/runs/31401329534)):

```
Error: [vite]: Rolldown failed to resolve import "pinia" from "/app/src/main.ts"
```

## Ursache

Beide Dockerfiles installieren den Workspace vom Repo-Root und kopieren dann **nur** `/app/node_modules` in die nächste Stage. Das setzt voraus, dass npm jede Workspace-Abhängigkeit ins Root hebt — was npm nicht garantiert. Bei einem Versionskonflikt nestet es das Paket stattdessen unter `<workspace>/node_modules`.

Pinia 4 bringt `@vue/devtools-api` als Peer mit, und dieser Konflikt genügt: `pinia`, `@vue/devtools-*`, `typescript` und `perfect-debounce` landen in `frontend/node_modules` — dorthin hat die builder-Stage nie geschaut.

```
$ ls frontend/node_modules
@vue  perfect-debounce  pinia  typescript

$ ls -d node_modules/pinia
(nicht vorhanden)
```

Die Nestung gab es vorher schon für `typescript` und `perfect-debounce` — nur importiert `src/main.ts` die nicht, also fiel es nicht auf. Pinia ist das erste genestete Paket im Import-Graphen des Builds.

## Fix

Den genesteten Baum über den gehoisteten legen. Der Source liegt flach unter `/app/`, es gibt also nur **eine** Auflösungsebene — und die muss der Sicht des Workspace entsprechen, wo Genestetes das Gehoistete überschattet. Das `mkdir -p` in der deps-Stage hält den `COPY` funktionsfähig, wenn npm zufällig doch alles hoistet.

Dieselbe Änderung im **Backend-Dockerfile**: es trägt dieselbe Annahme und überlebt bisher nur durch Glück der aktuellen Auflösung. #147 fügt eine Abhängigkeit hinzu — genau die Art Änderung, die das kippen lässt.

## Warum die PR-CI das nicht gefangen hat

`Deploy Backend` und `Deploy Frontend` sind bei PRs `SKIPPED` und laufen erst beim Push auf `main`. Die Image-Builds sind damit **strukturell ungetestet, bis gemergt wird**. Bei #142 hatte ich die Images deshalb lokal gebaut, bei #146 nicht — dort habe ich mich auf `npm run build` verlassen, und genau der läuft mit dem lokalen, vollständigen `node_modules` und kann diesen Fehler nicht zeigen.

## Verifikation

Fehler zunächst lokal reproduziert (identische Meldung), dann nach dem Fix beide Images gebaut:

- **Frontend**: Build grün, Container liefert `index.html` (HTTP 200) und `/health` (HTTP 200), alle drei Pinia-Store-IDs (`syncQueue`, `scoreSync`, `pwaUpdate`) im Bundle vorhanden, 22 JS-Chunks
- **Backend**: Build grün, `node -v` → v24.19.0, `fastify` auflösbar

`lint` und 217 Unit-Tests grün.

## Reihenfolge

Dieser PR sollte **vor #147** rein — er repariert `main`, und #147 fügt dem Backend eine Abhängigkeit hinzu, die dieselbe Falle auslösen könnte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
